### PR TITLE
小修正: props配列の破壊的reverseと「野州田川」誤字を修正

### DIFF
--- a/src/components/datatable.svelte
+++ b/src/components/datatable.svelte
@@ -8,8 +8,8 @@ const formatted: {
   showTime: boolean;
   count: number;
 }[] = [];
-const formattedAxis = axis.reverse();
-const formatteddata = data.reverse();
+const formattedAxis = [...axis].reverse();
+const formatteddata = [...data].reverse();
 for (let i = 0; i < formattedAxis.length; i++) {
   const date = fromUnixTime(formattedAxis[i]);
   const date_before = fromUnixTime(formattedAxis[i - 1]);

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -4,7 +4,7 @@ import { relays } from "$lib/config";
 
 <!-- {#if items} -->
 <div class="bg-main text-center py-2">
-  <div class="fs-1">野州田川水系</div>
+  <div class="fs-1">野洲田川水系</div>
   <div class="fs-3 mt-2">定点観測所</div>
 </div>
 <div class="row max-width mx-auto pt-3">


### PR DESCRIPTION
Closes #5
Closes #9

## 内容
方針決定済みの小修正2件をまとめて対応します。

### #5 DataTable の props 破壊的 reverse
`datatable.svelte` の `axis.reverse()` / `data.reverse()` を `[...axis].reverse()` / `[...data].reverse()` に変更。親から渡された配列(charts.svelte も同じ参照を使用)を破壊しないようにする。#4 の load 移行でデータがリアクティブに差し替わるようになる前の必須修正。

### #9 トップページの誤字
見出し「野**州**田川水系」→「野**洲**田川水系」に修正し、サイト全体の表記を統一。

## 確認済み
- `npm run build` ✅ / `npm run check` 0 errors ✅ / `npm run lint` エラー0 ✅
- `npm run preview` でトップページの表記が「野洲田川水系」に統一されたことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CstqXvSDoZrhAMXGmfzdeD