### PR TITLE
観測所ページの基盤改修: load移行・エラー処理・HTTP 404・リソース管理

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -149,3 +149,4 @@ dist
 package
 
 # End of https://www.toptal.com/developers/gitignore/api/svelte,node
+.claude/

--- a/src/components/charts.svelte
+++ b/src/components/charts.svelte
@@ -8,23 +8,18 @@ import {
 } from "chart.js";
 import "chartjs-adapter-date-fns";
 import { fromUnixTime } from "date-fns";
-import { onMount } from "svelte";
+import { onDestroy, onMount } from "svelte";
 export let axis: number[];
 export let data: number[];
 
-const formatted = {
+Chart.register(TimeScale, LinearScale, BarController, BarElement);
+
+let chartCanvas: HTMLCanvasElement;
+let chart: Chart | undefined;
+
+const buildChartData = (axis: number[], data: number[]) => ({
   labels: axis.map((item) => fromUnixTime(item)),
   datasets: [
-    // {
-    //   type: "line",
-    //   label: "移動平均",
-    //   data: items.map((item) => item.movingAvg),
-    //   cubicInterpolationMode: "monotone",
-    //   borderColor: "#113285",
-    //   borderWidth: 1.2,
-    //   borderJoinStyle: "none",
-    //   pointStyle: false,
-    // },
     {
       type: "bar" as const,
       label: "投稿数",
@@ -32,13 +27,16 @@ const formatted = {
       backgroundColor: "#58B2DC",
     },
   ],
-};
+});
 
-let chartCanvas: HTMLCanvasElement;
-Chart.register(TimeScale, LinearScale, BarController, BarElement);
-function renderChart() {
-  new Chart(chartCanvas, {
-    data: formatted,
+$: if (chart) {
+  chart.data = buildChartData(axis, data);
+  chart.update();
+}
+
+onMount(() => {
+  chart = new Chart(chartCanvas, {
+    data: buildChartData(axis, data),
     options: {
       animation: false,
       responsive: true,
@@ -66,10 +64,11 @@ function renderChart() {
       },
     },
   });
-}
+});
 
-onMount(() => {
-  renderChart();
+onDestroy(() => {
+  chart?.destroy();
+  chart = undefined;
 });
 </script>
 

--- a/src/components/datatable.svelte
+++ b/src/components/datatable.svelte
@@ -2,24 +2,31 @@
 import { format, fromUnixTime, isSameDay, isSameHour } from "date-fns";
 export let axis: number[];
 export let data: number[];
-const formatted: {
+type Row = {
   date: Date;
   showDate: boolean;
   showTime: boolean;
   count: number;
-}[] = [];
-const formattedAxis = [...axis].reverse();
-const formatteddata = [...data].reverse();
-for (let i = 0; i < formattedAxis.length; i++) {
-  const date = fromUnixTime(formattedAxis[i]);
-  const date_before = fromUnixTime(formattedAxis[i - 1]);
-  formatted.push({
-    date,
-    showDate: i === 0 || !isSameDay(date, date_before),
-    showTime: i === 0 || !isSameHour(date, date_before),
-    count: formatteddata[i],
-  });
+};
+
+function buildRows(axis: number[], data: number[]): Row[] {
+  const rows: Row[] = [];
+  const reversedAxis = [...axis].reverse();
+  const reversedData = [...data].reverse();
+  for (let i = 0; i < reversedAxis.length; i++) {
+    const date = fromUnixTime(reversedAxis[i]);
+    const date_before = fromUnixTime(reversedAxis[i - 1]);
+    rows.push({
+      date,
+      showDate: i === 0 || !isSameDay(date, date_before),
+      showTime: i === 0 || !isSameHour(date, date_before),
+      count: reversedData[i],
+    });
+  }
+  return rows;
 }
+
+$: formatted = buildRows(axis, data);
 </script>
 
 <span>測位情報 (posts / 10min)</span>

--- a/src/lib/app.ts
+++ b/src/lib/app.ts
@@ -8,26 +8,35 @@ const RELAYS = [
 ];
 const npub = "a3c13ef4c9eccfde01bd9326a2ab08b2ad7dc57f3b77db77723f8e2ad7ba24d6";
 
+const FETCH_TIMEOUT_MS = 10000;
+
+// 戻り値 null は「該当データなし」、例外は「取得失敗（接続不可・タイムアウト等）」
 export const getGraphData = async (tableName: string) => {
   const pool = new SimplePool();
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<never>((_, reject) => {
+    timer = setTimeout(
+      () => reject(new Error("relay fetch timeout")),
+      FETCH_TIMEOUT_MS,
+    );
+  });
   try {
-    const event = await pool.get(RELAYS, {
-      kinds: [30078],
-      authors: [npub],
-      "#d": [tableName],
-    });
+    const event = await Promise.race([
+      pool.get(RELAYS, {
+        kinds: [30078],
+        authors: [npub],
+        "#d": [tableName],
+      }),
+      timeout,
+    ]);
     if (!event) return null;
-    try {
-      const parsedContent = JSON.parse(event.content);
-      return {
-        axis: parsedContent.axis,
-        data: parsedContent.datas,
-      };
-    } catch (e) {
-      console.error("Failed to parse event content:", e);
-      return null;
-    }
+    const parsedContent = JSON.parse(event.content);
+    return {
+      axis: parsedContent.axis,
+      data: parsedContent.datas,
+    };
   } finally {
+    clearTimeout(timer);
     pool.close(RELAYS);
   }
 };

--- a/src/lib/app.ts
+++ b/src/lib/app.ts
@@ -8,23 +8,26 @@ const RELAYS = [
 ];
 const npub = "a3c13ef4c9eccfde01bd9326a2ab08b2ad7dc57f3b77db77723f8e2ad7ba24d6";
 
-const pool = new SimplePool();
-
 export const getGraphData = async (tableName: string) => {
-  const event = await pool.get(RELAYS, {
-    kinds: [30078],
-    authors: [npub],
-    "#d": [tableName],
-  });
-  if (!event) return null;
+  const pool = new SimplePool();
   try {
-    const parsedContent = JSON.parse(event.content);
-    return {
-      axis: parsedContent.axis,
-      data: parsedContent.datas,
-    };
-  } catch (e) {
-    console.error("Failed to parse event content:", e);
-    return null;
+    const event = await pool.get(RELAYS, {
+      kinds: [30078],
+      authors: [npub],
+      "#d": [tableName],
+    });
+    if (!event) return null;
+    try {
+      const parsedContent = JSON.parse(event.content);
+      return {
+        axis: parsedContent.axis,
+        data: parsedContent.datas,
+      };
+    } catch (e) {
+      console.error("Failed to parse event content:", e);
+      return null;
+    }
+  } finally {
+    pool.close(RELAYS);
   }
 };

--- a/src/routes/+error.svelte
+++ b/src/routes/+error.svelte
@@ -1,0 +1,22 @@
+<script lang="ts">
+import { page } from "$app/stores";
+</script>
+
+<div class="text-center bg-main p-2">
+  <span class="fs-5"><a href="/" class="text-light">野洲田川定点観測所</a></span
+  >
+</div>
+
+<div class="row max-width mx-auto text-center mt-5">
+  <div class="fs-1">{$page.status}</div>
+  <div class="fs-3">{$page.status === 404 ? "Not Found" : "Error"}</div>
+  <div class="mt-4">
+    {$page.error?.message ?? "エラーが発生しました"}
+  </div>
+</div>
+
+<style>
+  a {
+    text-decoration: none;
+  }
+</style>

--- a/src/routes/[relay]/+page.svelte
+++ b/src/routes/[relay]/+page.svelte
@@ -12,6 +12,7 @@ export let data: PageData;
 
 let axis: number[] | null = null;
 let counts: number[] | null = null;
+let status: "loading" | "ready" | "nodata" | "error" = "loading";
 let selectedDate = format(new Date(), "yyyy-MM-dd");
 let radioSelection = "0";
 let requestId = 0;
@@ -34,12 +35,23 @@ async function fetchData(relayKey: string, date: string | null) {
   const id = ++requestId;
   axis = null;
   counts = null;
+  status = "loading";
   const dateKey = date ? `_${date}` : "";
-  const result = await getGraphData(`nostr_river_flowmeter${dateKey}`);
-  if (id !== requestId) return;
-  if (!result) return;
-  axis = result.axis;
-  counts = relayKey in result.data ? result.data[relayKey] : [];
+  try {
+    const result = await getGraphData(`nostr_river_flowmeter${dateKey}`);
+    if (id !== requestId) return;
+    if (!result) {
+      status = date ? "nodata" : "error";
+      return;
+    }
+    axis = result.axis;
+    counts = relayKey in result.data ? result.data[relayKey] : [];
+    status = "ready";
+  } catch (e) {
+    if (id !== requestId) return;
+    console.error("Failed to fetch graph data:", e);
+    status = "error";
+  }
 }
 
 const update = () => {
@@ -112,7 +124,7 @@ const selectDate = () => {
 {/if}
 <div class="p-2"></div>
 
-{#if axis && counts}
+{#if status === "ready" && axis && counts}
   <div class="max-width mx-auto container">
     <BaseInfo {info} />
   </div>
@@ -123,6 +135,20 @@ const selectDate = () => {
     </div>
     <div class="col-12 col-md-9 order-1">
       <Charts {axis} data={counts} />
+    </div>
+  </div>
+{:else if status === "nodata"}
+  <div class="row max-width mx-auto text-center mt-5">
+    <div class="fs-1"></div>
+    <div class="fs-3">No Data</div>
+    <div class="mt-4">指定日の観測データがありません</div>
+  </div>
+{:else if status === "error"}
+  <div class="row max-width mx-auto text-center mt-5">
+    <div class="fs-1"></div>
+    <div class="fs-3">Error</div>
+    <div class="mt-4">
+      データを取得できませんでした。時間をおいて再読み込みしてください
     </div>
   </div>
 {:else}

--- a/src/routes/[relay]/+page.svelte
+++ b/src/routes/[relay]/+page.svelte
@@ -66,7 +66,7 @@ const selectDate = () => {
     <div class="bg-main py-2 px-3 head-sub-title">
       Nostr 日本語リレーリアルタイム流速検出システム
     </div>
-    <div class="pt-2">{info?.relay_url ?? ""}</div>
+    <div class="pt-2">{info.relay_url}</div>
   </div>
 </div>
 {#if info}
@@ -112,7 +112,7 @@ const selectDate = () => {
 {/if}
 <div class="p-2"></div>
 
-{#if axis && counts && info}
+{#if axis && counts}
   <div class="max-width mx-auto container">
     <BaseInfo {info} />
   </div>
@@ -125,17 +125,11 @@ const selectDate = () => {
       <Charts {axis} data={counts} />
     </div>
   </div>
-{:else if info}
+{:else}
   <div class="row max-width mx-auto text-center mt-5">
     <div class="fs-1"></div>
     <div class="fs-3">Now loading...</div>
     <div class="mt-4">読み込み中</div>
-  </div>
-{:else}
-  <div class="row max-width mx-auto text-center mt-5">
-    <div class="fs-1">404</div>
-    <div class="fs-3">Not Found</div>
-    <div class="mt-4">ページが見つかりません</div>
   </div>
 {/if}
 

--- a/src/routes/[relay]/+page.svelte
+++ b/src/routes/[relay]/+page.svelte
@@ -62,7 +62,8 @@ const update = () => {
   }
 };
 const selectDate = () => {
-  goto(`/${data.relayKey}?d=${format(new Date(selectedDate), "yyyyMMdd")}`);
+  const parsed = parse(selectedDate, "yyyy-MM-dd", new Date());
+  goto(`/${data.relayKey}?d=${format(parsed, "yyyyMMdd")}`);
 };
 </script>
 
@@ -96,27 +97,27 @@ const selectDate = () => {
         />
       </div>
       <div class="select-sector pt-2 pb-1 px-3 bg-white mt-2">
-        <label for="realtime" class="me-2">
+        <label for="mode-current" class="me-2">
           <input
             type="radio"
-            id="realtime"
+            id="mode-current"
             name="choice"
             value="0"
             bind:group={radioSelection}
             on:change={update}
           />
-          10分計測
+          現在
         </label>
-        <label for="minute_10">
+        <label for="mode-date">
           <input
             type="radio"
-            id="minute_10"
+            id="mode-date"
             name="choice"
             value="1"
             bind:group={radioSelection}
             on:change={update}
           />
-          正時刻
+          日付指定
         </label>
       </div>
     </div>

--- a/src/routes/[relay]/+page.svelte
+++ b/src/routes/[relay]/+page.svelte
@@ -1,57 +1,57 @@
 <script lang="ts">
-import { format, isValid, parse } from "date-fns";
-import { page } from "$app/stores";
+import { format, parse } from "date-fns";
+import { browser } from "$app/environment";
+import { goto } from "$app/navigation";
 import { getGraphData } from "$lib/app";
-import { getRelay, type RelayItem } from "$lib/config";
 import BaseInfo from "../../components/baseinfo.svelte";
 import Charts from "../../components/charts.svelte";
 import DataTable from "../../components/datatable.svelte";
+import type { PageData } from "./$types";
 
-const relay: string = $page.params.relay ?? "";
-const date = $page.url.searchParams.get("d");
+export let data: PageData;
+
+let axis: number[] | null = null;
+let counts: number[] | null = null;
 let selectedDate = format(new Date(), "yyyy-MM-dd");
 let radioSelection = "0";
+let requestId = 0;
 
-const query = $page.url.searchParams;
+$: info = data.info;
+$: syncControls(data.date);
+$: if (browser && info) fetchData(data.relayKey, data.date);
 
-if (date) {
-  const parsedDate = parse(date, "yyyyMMdd", new Date());
-  if (isValid(parsedDate)) {
-    selectedDate = format(parsedDate, "yyyy-MM-dd");
+function syncControls(date: string | null) {
+  if (date) {
+    selectedDate = format(parse(date, "yyyyMMdd", new Date()), "yyyy-MM-dd");
     radioSelection = "1";
   } else {
-    console.error("Invalid date parameter:", date);
+    selectedDate = format(new Date(), "yyyy-MM-dd");
+    radioSelection = "0";
   }
 }
 
-const update = async () => {
-  if (radioSelection === "0") {
-    selectedDate = format(new Date(), "yyyy-MM-dd");
-    query.delete("d");
-    history.replaceState(history.state, "", $page.url);
-    location.href = $page.url.toString();
-  }
-  if (radioSelection === "1") {
-    query.set("d", format(new Date(), "yyyyMMdd"));
-    history.replaceState(history.state, "", $page.url);
-    location.href = $page.url.toString();
-  }
-};
-const selectDate = async () => {
-  query.set("d", format(new Date(selectedDate), "yyyyMMdd"));
-  history.replaceState(history.state, "", $page.url);
-  location.href = $page.url.toString();
-};
-let axis: number[];
-let data: number[];
-(async () => {
+async function fetchData(relayKey: string, date: string | null) {
+  const id = ++requestId;
+  axis = null;
+  counts = null;
   const dateKey = date ? `_${date}` : "";
   const result = await getGraphData(`nostr_river_flowmeter${dateKey}`);
+  if (id !== requestId) return;
   if (!result) return;
   axis = result.axis;
-  data = relay in result.data ? result.data[relay] : [];
-})();
-const info: RelayItem | undefined = getRelay(relay);
+  counts = relayKey in result.data ? result.data[relayKey] : [];
+}
+
+const update = () => {
+  if (radioSelection === "0") {
+    goto(`/${data.relayKey}`);
+  } else {
+    goto(`/${data.relayKey}?d=${format(new Date(), "yyyyMMdd")}`);
+  }
+};
+const selectDate = () => {
+  goto(`/${data.relayKey}?d=${format(new Date(selectedDate), "yyyyMMdd")}`);
+};
 </script>
 
 <div class="text-center bg-main p-2">
@@ -112,18 +112,17 @@ const info: RelayItem | undefined = getRelay(relay);
 {/if}
 <div class="p-2"></div>
 
-{#if axis && data && info}
+{#if axis && counts && info}
   <div class="max-width mx-auto container">
     <BaseInfo {info} />
   </div>
   <div class="p-2"></div>
   <div class="row max-width mx-auto">
     <div class="col-12 col-md-3 order-2">
-      <DataTable {axis} {data} />
+      <DataTable {axis} data={counts} />
     </div>
     <div class="col-12 col-md-9 order-1">
-      <Charts {axis} {data} />
-      <!-- <Charts {items} /> -->
+      <Charts {axis} data={counts} />
     </div>
   </div>
 {:else if info}

--- a/src/routes/[relay]/+page.ts
+++ b/src/routes/[relay]/+page.ts
@@ -1,9 +1,13 @@
 import { getRelay } from "$lib/config";
+import { error } from "@sveltejs/kit";
 import { isValid, parse } from "date-fns";
 import type { PageLoad } from "./$types";
 
 export const load: PageLoad = ({ params, url }) => {
   const info = getRelay(params.relay);
+  if (!info) {
+    error(404, "ページが見つかりません");
+  }
 
   const dateParam = url.searchParams.get("d");
   let date: string | null = null;

--- a/src/routes/[relay]/+page.ts
+++ b/src/routes/[relay]/+page.ts
@@ -1,0 +1,24 @@
+import { getRelay } from "$lib/config";
+import { isValid, parse } from "date-fns";
+import type { PageLoad } from "./$types";
+
+export const load: PageLoad = ({ params, url }) => {
+  const info = getRelay(params.relay);
+
+  const dateParam = url.searchParams.get("d");
+  let date: string | null = null;
+  if (dateParam) {
+    const parsed = parse(dateParam, "yyyyMMdd", new Date());
+    if (isValid(parsed)) {
+      date = dateParam;
+    } else {
+      console.error("Invalid date parameter:", dateParam);
+    }
+  }
+
+  return {
+    relayKey: params.relay,
+    info,
+    date,
+  };
+};


### PR DESCRIPTION
Closes #4
Closes #7
Closes #8
Closes #12
Closes #17

## 内容
観測所ページ(`/[relay]`)の基盤改修一式。Issue ごとにコミットを分割しています。

### #12 リソースリーク解消
- Chart インスタンスを保持し `onDestroy` で `destroy()`、データ更新は `chart.data` 差し替え + `update()`
- SimplePool を取得ごとに生成し、完了後に必ず `close()`

### #4 load 関数移行・リレー間遷移バグ修正
- `+page.ts` を新設(観測所キー検証・日付パラメータ解析)
- ページをリアクティブ化し、観測所間のクライアントサイド遷移・日付切替で正しくデータを再取得
- `location.href` フルリロードを `goto()` に置き換え
- 古いレスポンスの後着上書きをリクエストIDで防止
- Nostr への接続はブラウザのみ(SSR では実行しない)

### #8 本物の HTTP 404
- load で `error(404)` を投げ、`+error.svelte` で従来の 404 デザインを再現(`/存在しないキー` が実ステータス 404 に)

### #7 タイムアウト・エラー表示
- リレー取得に 10 秒タイムアウト
- 「データを取得できませんでした」(取得失敗)と「指定日の観測データがありません」(データなし)を区別して表示

### #17 日付・文言
- `new Date("yyyy-MM-dd")` の UTC 解釈を `parse()` に変更し前日ずれを解消
- ラジオボタン文言を「現在」「日付指定」に変更

## 確認済み
- `npm run build` ✅ / `npm run check` 0 errors ✅ / `npm run lint` エラー0 ✅(各コミットごとに実施)
- preview で確認: 観測所ページの SSR 表示、`/存在しないキー` が HTTP 404、新ラベル表示

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CstqXvSDoZrhAMXGmfzdeD