### PR TITLE
グラフ改修: 移動平均線の復活とツールチップ・凡例追加

### DIFF
--- a/src/components/charts.svelte
+++ b/src/components/charts.svelte
@@ -3,8 +3,13 @@ import {
   BarController,
   BarElement,
   Chart,
+  Legend,
   LinearScale,
+  LineController,
+  LineElement,
+  PointElement,
   TimeScale,
+  Tooltip,
 } from "chart.js";
 import "chartjs-adapter-date-fns";
 import { fromUnixTime } from "date-fns";
@@ -12,14 +17,45 @@ import { onDestroy, onMount } from "svelte";
 export let axis: number[];
 export let data: number[];
 
-Chart.register(TimeScale, LinearScale, BarController, BarElement);
+Chart.register(
+  TimeScale,
+  LinearScale,
+  BarController,
+  BarElement,
+  LineController,
+  LineElement,
+  PointElement,
+  Tooltip,
+  Legend,
+);
 
 let chartCanvas: HTMLCanvasElement;
 let chart: Chart | undefined;
 
+// 6点(=1時間)移動平均。窓が埋まらない先頭5点は NaN にして描画しない
+const MOVING_AVERAGE_WINDOW = 6;
+const movingAverage = (values: number[], windowSize: number): number[] =>
+  values.map((_, index) => {
+    if (index < windowSize - 1) return Number.NaN;
+    let sum = 0;
+    for (let i = index - windowSize + 1; i <= index; i++) {
+      sum += values[i];
+    }
+    return sum / windowSize;
+  });
+
 const buildChartData = (axis: number[], data: number[]) => ({
   labels: axis.map((item) => fromUnixTime(item)),
   datasets: [
+    {
+      type: "line" as const,
+      label: "移動平均",
+      data: movingAverage(data, MOVING_AVERAGE_WINDOW),
+      cubicInterpolationMode: "monotone" as const,
+      borderColor: "#113285",
+      borderWidth: 1.2,
+      pointStyle: false as const,
+    },
     {
       type: "bar" as const,
       label: "投稿数",
@@ -58,7 +94,7 @@ onMount(() => {
         y: {
           title: {
             display: true,
-            text: "移動平均",
+            text: "投稿数 (posts/10min)",
           },
         },
       },


### PR DESCRIPTION
Closes #6

## 変更概要

`src/components/charts.svelte` のみ変更。

- **移動平均線の復活**: props の `data`(10分毎の投稿数)から 6点(=1時間)移動平均を算出し、線グラフ系列として追加
  - 窓が埋まらない先頭5点は `NaN` として描画しない
  - `type: "line"` / label「移動平均」/ borderColor `#113285` / borderWidth 1.2 / `cubicInterpolationMode: "monotone"` / `pointStyle: false`
  - 棒グラフ(label「投稿数」, backgroundColor `#58B2DC`)は現状のまま
- **Chart.register 追加**: `LineController` / `LineElement` / `PointElement` / `Tooltip` / `Legend`
- **Y軸タイトル修正**: 「移動平均」→「投稿数 (posts/10min)」
- **凡例・ツールチップ**: Legend / Tooltip を登録し、凡例表示とホバーでの時刻・投稿数・移動平均の確認が可能に
- リアクティブ更新(`$:` での `chart.data` 差し替え + `update()`)経路でも `buildChartData` 内で移動平均を再計算

Chart インスタンス保持 + `onDestroy` で destroy する既存構造は維持。

## 確認結果

- `npm run build`: 成功
- `npm run check`: 0 errors / 0 warnings
- `npm run lint`: charts.svelte はエラーなし(`src/routes/[relay]/+page.ts` の organizeImports エラーは develop 由来の既存問題で本 PR のスコープ外)
- 移動平均ロジックの単体確認: `[6,12,18,24,30,36,42,0]` → `[NaN×5, 21, 27, 25]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CstqXvSDoZrhAMXGmfzdeD