### PR TITLE
リアルタイム自動更新と欠測判定の実装

### DIFF
--- a/src/components/baseinfo.svelte
+++ b/src/components/baseinfo.svelte
@@ -1,6 +1,13 @@
 <script lang="ts">
 import type { RelayItem } from "$lib/config";
 export let info: RelayItem;
+export let operation: "計測中" | "欠測" | "過去ログ" = "計測中";
+
+const operationClasses = {
+  計測中: "text-success",
+  欠測: "text-danger",
+  過去ログ: "text-secondary",
+} as const;
 </script>
 
 <table>
@@ -29,7 +36,7 @@ export let info: RelayItem;
           ></span
         ></td
       >
-      <td class="text-success"><span>計測中</span></td>
+      <td class={operationClasses[operation]}><span>{operation}</span></td>
     </tr>
   </tbody>
 </table>

--- a/src/routes/[relay]/+page.svelte
+++ b/src/routes/[relay]/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 import { format, parse } from "date-fns";
+import { onDestroy, onMount } from "svelte";
 import { browser } from "$app/environment";
 import { goto } from "$app/navigation";
 import { getGraphData } from "$lib/app";
@@ -10,16 +11,21 @@ import type { PageData } from "./$types";
 
 export let data: PageData;
 
+const REFRESH_INTERVAL_MS = 5 * 60 * 1000;
+
 let axis: number[] | null = null;
 let counts: number[] | null = null;
 let status: "loading" | "ready" | "nodata" | "error" = "loading";
 let selectedDate = format(new Date(), "yyyy-MM-dd");
 let radioSelection = "0";
 let requestId = 0;
+let lastUpdated: Date | null = null;
+let refreshTimer: ReturnType<typeof setInterval> | null = null;
 
 $: info = data.info;
 $: syncControls(data.date);
 $: if (browser && info) fetchData(data.relayKey, data.date);
+$: if (browser) syncAutoRefresh(data.date);
 
 function syncControls(date: string | null) {
   if (date) {
@@ -31,26 +37,83 @@ function syncControls(date: string | null) {
   }
 }
 
-async function fetchData(relayKey: string, date: string | null) {
+function startAutoRefresh() {
+  if (refreshTimer !== null) return;
+  refreshTimer = setInterval(() => {
+    fetchData(data.relayKey, data.date, true);
+  }, REFRESH_INTERVAL_MS);
+}
+
+function stopAutoRefresh() {
+  if (refreshTimer !== null) {
+    clearInterval(refreshTimer);
+    refreshTimer = null;
+  }
+}
+
+// リアルタイム表示（date が null）のときだけ自動更新する
+function syncAutoRefresh(date: string | null) {
+  stopAutoRefresh();
+  if (date === null && !document.hidden) {
+    startAutoRefresh();
+  }
+}
+
+// タブ非表示中は自動更新を止め、復帰時に即時更新して再開する
+function handleVisibilityChange() {
+  if (document.hidden) {
+    stopAutoRefresh();
+  } else if (data.date === null) {
+    fetchData(data.relayKey, data.date, true);
+    startAutoRefresh();
+  }
+}
+
+onMount(() => {
+  document.addEventListener("visibilitychange", handleVisibilityChange);
+});
+
+onDestroy(() => {
+  stopAutoRefresh();
+  if (browser) {
+    document.removeEventListener("visibilitychange", handleVisibilityChange);
+  }
+});
+
+// silent: 自動更新用。既存表示を維持したまま裏で取得し、成功時のみ差し替える
+async function fetchData(
+  relayKey: string,
+  date: string | null,
+  silent = false,
+) {
   const id = ++requestId;
-  axis = null;
-  counts = null;
-  status = "loading";
+  if (!silent) {
+    axis = null;
+    counts = null;
+    status = "loading";
+  }
   const dateKey = date ? `_${date}` : "";
   try {
     const result = await getGraphData(`nostr_river_flowmeter${dateKey}`);
     if (id !== requestId) return;
     if (!result) {
-      status = date ? "nodata" : "error";
+      if (silent) {
+        console.error("Auto refresh returned no data");
+      } else {
+        status = date ? "nodata" : "error";
+      }
       return;
     }
     axis = result.axis;
     counts = relayKey in result.data ? result.data[relayKey] : [];
     status = "ready";
+    lastUpdated = new Date();
   } catch (e) {
     if (id !== requestId) return;
     console.error("Failed to fetch graph data:", e);
-    status = "error";
+    if (!silent) {
+      status = "error";
+    }
   }
 }
 
@@ -95,6 +158,9 @@ const selectDate = () => {
           bind:value={selectedDate}
           on:change={selectDate}
         />
+        {#if data.date === null && lastUpdated}
+          <div class="text-end">最終更新: {format(lastUpdated, "HH:mm")}</div>
+        {/if}
       </div>
       <div class="select-sector pt-2 pb-1 px-3 bg-white mt-2">
         <label for="mode-current" class="me-2">

--- a/src/routes/[relay]/+page.svelte
+++ b/src/routes/[relay]/+page.svelte
@@ -12,6 +12,9 @@ import type { PageData } from "./$types";
 export let data: PageData;
 
 const REFRESH_INTERVAL_MS = 5 * 60 * 1000;
+const MISSING_THRESHOLD_SEC = 30 * 60;
+
+type Operation = "計測中" | "欠測" | "過去ログ";
 
 let axis: number[] | null = null;
 let counts: number[] | null = null;
@@ -21,6 +24,7 @@ let radioSelection = "0";
 let requestId = 0;
 let lastUpdated: Date | null = null;
 let refreshTimer: ReturnType<typeof setInterval> | null = null;
+let operation: Operation = "計測中";
 
 $: info = data.info;
 $: syncControls(data.date);
@@ -80,6 +84,15 @@ onDestroy(() => {
   }
 });
 
+// 最終観測時刻が閾値より古ければ「欠測」、過去ログ表示時は判定しない
+function judgeOperation(date: string | null, axisData: number[]): Operation {
+  if (date) return "過去ログ";
+  if (axisData.length === 0) return "欠測";
+  const latest = Math.max(...axisData);
+  const nowSec = Math.floor(Date.now() / 1000);
+  return nowSec - latest > MISSING_THRESHOLD_SEC ? "欠測" : "計測中";
+}
+
 // silent: 自動更新用。既存表示を維持したまま裏で取得し、成功時のみ差し替える
 async function fetchData(
   relayKey: string,
@@ -108,6 +121,7 @@ async function fetchData(
     counts = relayKey in result.data ? result.data[relayKey] : [];
     status = "ready";
     lastUpdated = new Date();
+    operation = judgeOperation(date, result.axis);
   } catch (e) {
     if (id !== requestId) return;
     console.error("Failed to fetch graph data:", e);
@@ -193,7 +207,7 @@ const selectDate = () => {
 
 {#if status === "ready" && axis && counts}
   <div class="max-width mx-auto container">
-    <BaseInfo {info} />
+    <BaseInfo {info} {operation} />
   </div>
   <div class="p-2"></div>
   <div class="row max-width mx-auto">

--- a/src/routes/[relay]/+page.ts
+++ b/src/routes/[relay]/+page.ts
@@ -1,6 +1,6 @@
-import { getRelay } from "$lib/config";
 import { error } from "@sveltejs/kit";
 import { isValid, parse } from "date-fns";
+import { getRelay } from "$lib/config";
 import type { PageLoad } from "./$types";
 
 export const load: PageLoad = ({ params, url }) => {


### PR DESCRIPTION
Closes #10
Closes #11

## 変更概要

### Issue #10: リアルタイム表示の自動更新と最終更新時刻
- リアルタイム表示時(日付未指定)のみ、5分間隔で自動再取得
- 自動更新はサイレントモード(`fetchData(..., silent = true)`)で裏取得し、成功時のみ表示を差し替え。失敗時は既存表示を維持し `console.error` のみ
- 取得成功のたびに `lastUpdated` を記録し、日付選択エリアの下に「最終更新: HH:mm」を表示(過去ログ表示時は非表示)
- `visibilitychange` でタブ非表示中はインターバル停止、表示復帰時に即時更新して再開
- モード切替(現在⇔日付指定)でリアクティブにインターバルを開始/停止。`onDestroy` でインターバルとイベントリスナを確実に解除
- 既存の `requestId` により古いレスポンスの上書きを防止

### Issue #11: 稼働状況の欠測判定
- 取得データの最終タイムスタンプ(axis の最大値、unix 秒)と現在時刻を比較し、30分超過なら「欠測」、以内なら「計測中」
- `baseinfo.svelte` の稼働状況を `operation` props 化(計測中=text-success / 欠測=text-danger / 過去ログ=text-secondary)
- 過去ログ表示時は判定せず「過去ログ」を表示
- 判定は取得成功のタイミングで再計算(自動更新のたびに更新)

### その他
- `+page.ts` の import 順を Biome の safe fix で整理(develop で `npm run lint` が失敗していたため)

## 確認結果
- `npm run build` / `npm run check`(0 errors)/ `npm run lint`(exit 0)すべて通過
- `npm run preview` + curl で `/yabumi`(リアルタイム)と `/yabumi?d=20260703`(過去ログ)の SSR が HTTP 200 で表示されることを確認
- `src/components/charts.svelte` と `src/styles/style.scss` は未変更

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CstqXvSDoZrhAMXGmfzdeD