### PR TITLE
旧Vercel URLへのアクセスに移転のお知らせを表示

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,11 +1,31 @@
 <script lang="ts">
+import { browser } from "$app/environment";
 import { relays } from "$lib/config";
+
+const NEW_SITE_URL = "https://nostr-flowmeter.shino3.net/";
+// 旧 Vercel URL で閲覧しているときだけ移転案内を表示する
+const showMigrationNotice =
+  browser && location.hostname.endsWith(".vercel.app");
 </script>
 
 <div class="bg-main text-center py-2">
   <div class="fs-1">野洲田川水系</div>
   <div class="fs-3 mt-2">定点観測所</div>
 </div>
+{#if showMigrationNotice}
+  <div class="max-width mx-auto px-3">
+    <div class="migration-notice mt-3 p-3 text-center">
+      <div class="fs-4 text-danger">移転のお知らせ</div>
+      <div class="mt-2">
+        野洲田川定点観測所は下記のURLへ移転しました。<br />
+        お手数ですが、ブックマーク等の変更をお願いいたします。
+      </div>
+      <div class="fs-5 mt-2">
+        新URL: <a href={NEW_SITE_URL} class="text-primary">{NEW_SITE_URL}</a>
+      </div>
+    </div>
+  </div>
+{/if}
 <div class="row max-width mx-auto pt-3">
   <div class="col-12">
     このサイトは Nostr 日本リレーの流速をグラフ表示化しています。<br />
@@ -104,6 +124,10 @@ import { relays } from "$lib/config";
 </div>
 
 <style>
+  .migration-notice {
+    border: 2px solid #dc3545;
+    background-color: #fff;
+  }
   table {
     width: 100%;
     border: 1px solid #000;


### PR DESCRIPTION
Closes #29

## 内容
Cloudflare への移行（#21）に伴い、旧 Vercel URL（`*.vercel.app`）で閲覧している訪問者にのみ、トップページ上部へ「移転のお知らせ」を表示して新URL https://nostr-flowmeter.shino3.net/ へ誘導します。

- 判定はクライアントサイド（`location.hostname.endsWith(".vercel.app")`）。新ドメイン・ローカル開発・Cloudflare プレビューでは表示されない
- デザインは赤枠の告知ボックス（官公庁サイト風の告知に寄せたシンプルな枠）

## 注意
- 旧 Vercel 本番にこの案内を出すには main への反映が必要です。本PRを develop にマージすると、オープン中のリリース PR #28（develop → main）に自動的に含まれます
- 表示確認は Vercel のプレビューデプロイURL（*.vercel.app）で可能です（プレビューもホスト判定に合致するため案内が表示されます）

## 確認済み
- `npm run build` ✅ / `npm run check` 0 errors ✅ / `npm run lint` エラー0 ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CstqXvSDoZrhAMXGmfzdeD