### PR TITLE
グラフ整理と流速水準線の追加

### DIFF
--- a/src/components/charts.svelte
+++ b/src/components/charts.svelte
@@ -14,6 +14,7 @@ import {
 import "chartjs-adapter-date-fns";
 import { fromUnixTime } from "date-fns";
 import { onDestroy, onMount } from "svelte";
+import { FLOW_LEVELS } from "$lib/config";
 export let axis: number[];
 export let data: number[];
 
@@ -44,6 +45,9 @@ const movingAverage = (values: number[], windowSize: number): number[] =>
     return sum / windowSize;
   });
 
+// 流速水準線(ツールチップには表示しない)
+const LEVEL_LINE_LABELS = ["流速注意水準", "氾濫危険水準"];
+
 const buildChartData = (axis: number[], data: number[]) => ({
   labels: axis.map((item) => fromUnixTime(item)),
   datasets: [
@@ -54,6 +58,22 @@ const buildChartData = (axis: number[], data: number[]) => ({
       cubicInterpolationMode: "monotone" as const,
       borderColor: "#113285",
       borderWidth: 1.2,
+      pointStyle: false as const,
+    },
+    {
+      type: "line" as const,
+      label: "流速注意水準",
+      data: axis.map(() => FLOW_LEVELS.attention),
+      borderColor: "#d4a017",
+      borderWidth: 1.5,
+      pointStyle: false as const,
+    },
+    {
+      type: "line" as const,
+      label: "氾濫危険水準",
+      data: axis.map(() => FLOW_LEVELS.danger),
+      borderColor: "#dc3545",
+      borderWidth: 1.5,
       pointStyle: false as const,
     },
     {
@@ -77,6 +97,12 @@ onMount(() => {
       animation: false,
       responsive: true,
       maintainAspectRatio: false,
+      plugins: {
+        tooltip: {
+          filter: (item) =>
+            !LEVEL_LINE_LABELS.includes(item.dataset.label ?? ""),
+        },
+      },
       scales: {
         x: {
           type: "time",
@@ -92,6 +118,7 @@ onMount(() => {
           },
         },
         y: {
+          suggestedMax: FLOW_LEVELS.danger * 1.1,
           title: {
             display: true,
             text: "投稿数 (posts/10min)",

--- a/src/components/charts.svelte
+++ b/src/components/charts.svelte
@@ -76,7 +76,7 @@ onMount(() => {
     options: {
       animation: false,
       responsive: true,
-      aspectRatio: 1,
+      maintainAspectRatio: false,
       scales: {
         x: {
           type: "time",
@@ -109,26 +109,18 @@ onDestroy(() => {
 </script>
 
 <div class="mx-auto chart_size">
-  <canvas bind:this={chartCanvas} class="img-fluid canvas"></canvas>
+  <canvas bind:this={chartCanvas}></canvas>
 </div>
 
 <style>
-  .canvas {
-    min-width: 300px;
-    min-height: 300px;
-    width: 85vw;
-    height: 85vw;
-  }
   .chart_size {
-    min-width: 300px;
-    min-height: 300px;
-    width: 85vw;
-    height: 85vw;
+    position: relative;
+    width: 100%;
+    aspect-ratio: 2 / 1;
   }
-  @media (min-width: 768px) {
+  @media (max-width: 767px) {
     .chart_size {
-      width: 100%;
-      height: initial;
+      aspect-ratio: 4 / 3;
     }
   }
 </style>

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -70,7 +70,7 @@ export const getRelay = (key: string): RelayItem | undefined => {
   return relays.find((item) => item.key === key);
 };
 
-// 流速水準(官公庁の水位基準風、単位: posts/10min)。プレビュー後に調整可
+// 流速水準（官公庁の水位基準風、単位: posts/10min）。プレビュー後に調整可
 export type FlowLevels = {
   attention: number;
   danger: number;

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -69,3 +69,14 @@ export const relays: Relays = [
 export const getRelay = (key: string): RelayItem | undefined => {
   return relays.find((item) => item.key === key);
 };
+
+// 流速水準(官公庁の水位基準風、単位: posts/10min)。プレビュー後に調整可
+export type FlowLevels = {
+  attention: number;
+  danger: number;
+};
+
+export const FLOW_LEVELS: FlowLevels = {
+  attention: 100,
+  danger: 200,
+};


### PR DESCRIPTION
## 概要

Closes #31
Closes #34

### グラフサイズの整理 (#31)

- `.canvas` / `.chart_size` の vw 指定・min-width/min-height を撤去し、コンテナ div の `width: 100%; aspect-ratio: 2 / 1;`(モバイルは `4 / 3`)に一本化
- Chart.js 側は `responsive: true, maintainAspectRatio: false` として canvas がコンテナに追従する構造に変更
- 既存の Chart インスタンス保持 / onDestroy での destroy / `$:` での data 差し替え+update() 構造は維持

### 流速水準線と凡例 (#34)

- `src/lib/config.ts` に `FLOW_LEVELS`(流速注意水準 / 氾濫危険水準)を追加
- グラフに「流速注意水準」(#d4a017)・「氾濫危険水準」(#dc3545)の水平線データセットを追加し、凡例にも表示
- ツールチップには水準線を表示しない(`plugins.tooltip.filter` で除外)
- Y軸に `suggestedMax: FLOW_LEVELS.danger * 1.1` を設定し、水準線が常に見えるように調整

## 注意

水準値(注意 100 / 危険 200 posts/10min)は**仮の値**です。プレビューで実際の流速と見比べたうえで調整する前提です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CstqXvSDoZrhAMXGmfzdeD