### PR TITLE
諸元表・データ表の官公庁様式化

### DIFF
--- a/src/components/baseinfo.svelte
+++ b/src/components/baseinfo.svelte
@@ -23,6 +23,9 @@ $: specRows = [
   { label: "水系名", value: "野洲田川水系" },
   { label: "河川名", value: info.river_name },
   { label: "観測所", value: "野洲田川定点観測所" },
+  { label: "所在地", value: info.relay_url },
+  { label: "観測項目", value: "流速（投稿数）" },
+  { label: "観測方式", value: "テレメータ（自動観測・毎分）" },
   { label: "ライブカメラ", value: info.live_cam ? "○" : "✕" },
   { label: "観測システム", value: "流速ちゃん", link: systemUrl },
   {

--- a/src/components/baseinfo.svelte
+++ b/src/components/baseinfo.svelte
@@ -8,38 +8,79 @@ const operationClasses = {
   欠測: "text-danger",
   過去ログ: "text-secondary",
 } as const;
+
+const systemUrl =
+  "https://nostx.shino3.net/npub150qnaaxfan8auqdajvn292cgk2khm3tl8dmakamj878z44a6yntqk7uktv";
+
+type SpecRow = {
+  label: string;
+  value: string;
+  link?: string;
+  className?: string;
+};
+
+$: specRows = [
+  { label: "水系名", value: "野洲田川水系" },
+  { label: "河川名", value: info.river_name },
+  { label: "観測所", value: "野洲田川定点観測所" },
+  { label: "ライブカメラ", value: info.live_cam ? "○" : "✕" },
+  { label: "観測システム", value: "流速ちゃん", link: systemUrl },
+  {
+    label: "稼働状況",
+    value: operation,
+    className: operationClasses[operation],
+  },
+] satisfies SpecRow[];
 </script>
 
-<table>
-  <thead>
-    <tr class="bg-sub">
-      <th><span>水系名</span></th>
-      <th><span>河川名</span></th>
-      <th><span>観測所</span></th>
-      <th><span>ライブカメラ</span></th>
-      <th><span>観測システム</span></th>
-      <th><span>稼働状況</span></th>
-    </tr>
-  </thead>
+<!-- md 以上: 見出し行 + 値行の横並び表 -->
+<div class="spec-wide-container">
+  <table class="spec-table spec-table-wide">
+    <thead>
+      <tr class="bg-sub">
+        {#each specRows as row}
+          <th>{row.label}</th>
+        {/each}
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        {#each specRows as row}
+          <td class={row.className ?? ""}>
+            {#if row.link}
+              <a href={row.link} class="text-primary" target="_blank" rel="noopener noreferrer"
+                >{row.value}</a
+              >
+            {:else}
+              {row.value}
+            {/if}
+          </td>
+        {/each}
+      </tr>
+    </tbody>
+  </table>
+</div>
+
+<!-- md 未満: 「項目 | 値」の2列縦表 -->
+<table class="spec-table spec-table-narrow">
   <tbody>
-    <tr>
-      <td><span>野洲田川水系</span></td>
-      <td><span>{info.river_name}</span></td>
-      <td><span>野洲田川定点観測所</span></td>
-      <td><span>{info.live_cam ? "○" : "✕"}</span></td>
-      <td
-        ><span
-          ><a
-            href="https://nostx.shino3.net/npub150qnaaxfan8auqdajvn292cgk2khm3tl8dmakamj878z44a6yntqk7uktv"
-            class="text-primary"
-            target="_blank" rel="noopener noreferrer">流速ちゃん</a
-          ></span
-        ></td
-      >
-      <td class={operationClasses[operation]}><span>{operation}</span></td>
-    </tr>
+    {#each specRows as row}
+      <tr>
+        <th class="bg-sub" scope="row">{row.label}</th>
+        <td class={row.className ?? ""}>
+          {#if row.link}
+            <a href={row.link} class="text-primary" target="_blank" rel="noopener noreferrer"
+              >{row.value}</a
+            >
+          {:else}
+            {row.value}
+          {/if}
+        </td>
+      </tr>
+    {/each}
   </tbody>
 </table>
+
 {#if info.live_cam}
   <div class="text-end mt-2">
     <a href={info.live_cam_url} target="_blank" rel="noopener noreferrer" class="text-danger"
@@ -49,27 +90,38 @@ const operationClasses = {
 {/if}
 
 <style>
-  table {
+  .spec-table {
     width: 100%;
     border: 1px solid #000;
-    writing-mode: vertical-lr;
   }
-  @media (min-width: 768px) {
-    table {
-      -ms-writing-mode: initial;
-      writing-mode: initial;
-    }
-  }
-  td,
-  th {
+  .spec-table td,
+  .spec-table th {
     padding: 2px 7px;
     border: 1px solid #000;
     text-align: center;
     height: 1.5rem;
   }
-  td > span,
-  th > span {
-    writing-mode: horizontal-tb;
+  .spec-wide-container {
+    display: none;
+  }
+  .spec-table-wide td,
+  .spec-table-wide th {
     white-space: nowrap;
+  }
+  .spec-table-narrow th {
+    width: 40%;
+    white-space: nowrap;
+  }
+  .spec-table-narrow td {
+    word-break: break-all;
+  }
+  @media (min-width: 768px) {
+    .spec-wide-container {
+      display: block;
+      overflow-x: auto;
+    }
+    .spec-table-narrow {
+      display: none;
+    }
   }
 </style>

--- a/src/components/datatable.svelte
+++ b/src/components/datatable.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 import { format, fromUnixTime, isSameDay, isSameHour } from "date-fns";
+import { FLOW_LEVELS } from "$lib/config";
 export let axis: number[];
 export let data: number[];
 type Row = {
@@ -29,7 +30,10 @@ function buildRows(axis: number[], data: number[]): Row[] {
 $: formatted = buildRows(axis, data);
 </script>
 
-<span>測位情報 (posts / 10min)</span>
+<div class="table-label">
+  <span>観測値</span>
+  <span class="unit-note">(単位: 投稿/10分)</span>
+</div>
 <div class="table-container">
   <table>
     <thead class="sticky-top">
@@ -50,7 +54,11 @@ $: formatted = buildRows(axis, data);
             >{#if item.showTime}{format(item.date, "HH")}{/if}</td
           >
           <td>{format(item.date, "mm")}</td>
-          <td class="text-end no-border-left">{item.count}</td>
+          <td
+            class="text-end no-border-left"
+            class:level-attention={item.count >= FLOW_LEVELS.attention}
+            class:level-danger={item.count >= FLOW_LEVELS.danger}>{item.count}</td
+          >
         </tr>
       {/each}
     </tbody>
@@ -81,6 +89,20 @@ $: formatted = buildRows(axis, data);
   }
   .no-border-left {
     border-left: solid 1px #000;
+  }
+  .table-label {
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+  }
+  .unit-note {
+    font-size: 12px;
+  }
+  .level-attention {
+    background-color: #fff3cd;
+  }
+  .level-danger {
+    background-color: #f8d7da;
   }
   table {
     width: 100%;

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -69,3 +69,14 @@ export const relays: Relays = [
 export const getRelay = (key: string): RelayItem | undefined => {
   return relays.find((item) => item.key === key);
 };
+
+// 流速水準（官公庁の水位基準風、単位: posts/10min）。プレビュー後に調整可
+export type FlowLevels = {
+  attention: number;
+  danger: number;
+};
+
+export const FLOW_LEVELS: FlowLevels = {
+  attention: 100,
+  danger: 200,
+};


### PR DESCRIPTION
## 概要

Issue #32 と Issue #38 の一部(諸元表拡充・データ表のセル強調・単位注記)を実装しました。

Closes #32
Refs #38(パンくずリストは別 PR で対応のため Refs)

## 変更内容

### 諸元表(baseinfo.svelte)
- モバイル表示の `writing-mode: vertical-lr` による力技を全廃し、md(768px)未満では「項目 | 値」の2列縦表(官公庁の諸元表のスマホ表示様式)に変更。md 以上は現行どおり見出し行+値行の横並び表
- 実装は諸元を配列で定義し、2つのマークアップ(横並び表 / 2列縦表)を CSS の display 切替で出し分け
- 諸元行を追加: 「所在地」= リレー URL、「観測項目」= 流速(投稿数)、「観測方式」= テレメータ(自動観測・毎分)
- `operation` prop(計測中/欠測/過去ログ の色分け)とライブカメラリンクは維持

### データ表(datatable.svelte)
- 表の上のラベルを「観測値」とし、右肩に小さく「(単位: 投稿/10分)」の単位注記を追加
- 流速セルの背景を `count >= danger(200)` で赤系(#f8d7da)、`count >= attention(100)` で黄系(#fff3cd)に強調(官公庁の基準超過セル風)

### 設定(config.ts)
- 流速水準 `FLOW_LEVELS`(attention: 100 / danger: 200、単位: posts/10min)を追加。プレビュー後に調整可

## 検証

- `npm run build` / `npm run check` / `npm run lint` 全通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CstqXvSDoZrhAMXGmfzdeD