### PR TITLE
官公庁風フッターと文字サイズ変更・印刷用表示の追加

### DIFF
--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,11 +1,54 @@
-<script>
+<script lang="ts">
 import "../styles/style.scss";
+import { onMount } from "svelte";
+import { browser } from "$app/environment";
 import { page } from "$app/stores";
 import { getRelay } from "$lib/config";
 
 $: river_name = $page.params.relay
   ? "（" + getRelay($page.params.relay)?.river_name + "）"
   : "";
+
+type FontSize = "small" | "normal" | "large";
+
+const FONT_SIZE_KEY = "fontSize";
+let fontSize: FontSize = "normal";
+
+function applyFontSize(size: FontSize): void {
+  if (!browser) return;
+  document.body.classList.remove("fs-small", "fs-large");
+  if (size === "small") document.body.classList.add("fs-small");
+  if (size === "large") document.body.classList.add("fs-large");
+}
+
+function setFontSize(size: FontSize): void {
+  if (!browser) return;
+  fontSize = size;
+  applyFontSize(size);
+  try {
+    localStorage.setItem(FONT_SIZE_KEY, size);
+  } catch {
+    // localStorage が使えない環境では保存しない
+  }
+}
+
+function printPage(): void {
+  if (!browser) return;
+  window.print();
+}
+
+onMount(() => {
+  let saved: string | null = null;
+  try {
+    saved = localStorage.getItem(FONT_SIZE_KEY);
+  } catch {
+    saved = null;
+  }
+  if (saved === "small" || saved === "normal" || saved === "large") {
+    fontSize = saved;
+    applyFontSize(saved);
+  }
+});
 </script>
 
 <svelte:head>
@@ -17,6 +60,35 @@ $: river_name = $page.params.relay
   <meta property="og:url" content={$page.url.href}>
   <meta name="twitter:card" content="summary">
 </svelte:head>
+
+<div class="utility-bar">
+  <div class="utility-bar-inner max-width">
+    <span class="utility-label">文字サイズ:</span>
+    <button
+      type="button"
+      class="utility-btn"
+      class:active={fontSize === "small"}
+      on:click={() => setFontSize("small")}>小</button
+    >
+    <span class="utility-sep">|</span>
+    <button
+      type="button"
+      class="utility-btn"
+      class:active={fontSize === "normal"}
+      on:click={() => setFontSize("normal")}>標準</button
+    >
+    <span class="utility-sep">|</span>
+    <button
+      type="button"
+      class="utility-btn"
+      class:active={fontSize === "large"}
+      on:click={() => setFontSize("large")}>大</button
+    >
+    <button type="button" class="utility-btn utility-print" on:click={printPage}
+      >印刷用表示</button
+    >
+  </div>
+</div>
 
 <slot />
 
@@ -49,6 +121,67 @@ $: river_name = $page.params.relay
 </footer>
 
 <style>
+  :global(body.fs-small) {
+    font-size: 11px;
+  }
+
+  :global(body.fs-large) {
+    font-size: 15px;
+  }
+
+  .utility-bar {
+    background-color: #f2f2f2;
+    border-bottom: 1px solid #ddd;
+  }
+
+  .utility-bar-inner {
+    margin: 0 auto;
+    padding: 2px 16px;
+    text-align: right;
+    font-size: 11px;
+    color: #333;
+  }
+
+  .utility-label {
+    margin-right: 4px;
+  }
+
+  .utility-sep {
+    color: #999;
+  }
+
+  .utility-btn {
+    background: none;
+    border: none;
+    border-radius: 0;
+    padding: 1px 4px;
+    font-size: 11px;
+    color: #333;
+    cursor: pointer;
+    text-decoration: underline;
+  }
+
+  .utility-btn.active {
+    font-weight: bold;
+    text-decoration: none;
+    background-color: #0b346e;
+    color: #fff;
+  }
+
+  .utility-print {
+    margin-left: 16px;
+  }
+
+  @media print {
+    .utility-bar {
+      display: none;
+    }
+
+    .footer-links {
+      display: none;
+    }
+  }
+
   .site-footer {
     margin-top: 48px;
     background-color: #0b346e;

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -19,3 +19,86 @@ $: river_name = $page.params.relay
 </svelte:head>
 
 <slot />
+
+<footer class="site-footer">
+  <div class="site-footer-inner max-width">
+    <div class="footer-links">
+      <h2 class="footer-heading">関係機関リンク</h2>
+      <ul class="footer-link-list">
+        <li>
+          <a
+            href="https://nostx.shino3.net/npub150qnaaxfan8auqdajvn292cgk2khm3tl8dmakamj878z44a6yntqk7uktv"
+            target="_blank"
+            rel="noopener noreferrer">流速ちゃん</a
+          >
+        </li>
+        <li>
+          <a
+            href="https://github.com/ShinoharaTa/nostr-flowmeter-site"
+            target="_blank"
+            rel="noopener noreferrer">ページソース（GitHub）</a
+          >
+        </li>
+      </ul>
+    </div>
+    <p class="footer-operator">運営: 野洲田川定点観測所（サイト管理者: shino3）</p>
+    <p class="footer-copyright">
+      Copyright &copy; 野洲田川定点観測所 All Rights Reserved.
+    </p>
+  </div>
+</footer>
+
+<style>
+  .site-footer {
+    margin-top: 48px;
+    background-color: #0b346e;
+    color: #fff;
+    border-radius: 0;
+  }
+
+  .site-footer-inner {
+    margin: 0 auto;
+    padding: 24px 16px 12px;
+  }
+
+  .footer-heading {
+    font-size: 14px;
+    font-weight: bold;
+    margin: 0 0 8px;
+    padding-left: 8px;
+    border-left: 4px solid #fff;
+  }
+
+  .footer-link-list {
+    list-style: none;
+    margin: 0 0 16px;
+    padding: 0;
+  }
+
+  .footer-link-list li {
+    display: inline-block;
+    margin-right: 24px;
+  }
+
+  .footer-link-list a {
+    color: #cfe0f5;
+    text-decoration: underline;
+  }
+
+  .footer-link-list a:hover {
+    color: #fff;
+  }
+
+  .footer-operator {
+    margin: 0 0 16px;
+    font-size: 12px;
+  }
+
+  .footer-copyright {
+    margin: 0;
+    padding: 8px 0;
+    border-top: 1px solid #3a5a92;
+    font-size: 11px;
+    text-align: center;
+  }
+</style>


### PR DESCRIPTION
## 概要

- 官公庁風の全ページ共通フッターを追加(紺背景 #0B346E・白文字・直角)
  - 「関係機関リンク」見出し + 流速ちゃん / ページソース(GitHub)へのリンク(target="_blank" rel="noopener noreferrer")
  - 運営者表記「運営: 野洲田川定点観測所（サイト管理者: shino3）」
  - 最下段に Copyright 表記(小さく中央寄せ)
- ページ最上部に官公庁風のユーティリティバーを追加
  - 文字サイズ「小 | 標準 | 大」切替(body へのクラス付与、localStorage に保存し onMount で復元、SSR では browser ガードで何もしない)
  - 「印刷用表示」で window.print() を実行。@media print でユーティリティバーとフッターの関係機関リンクを非表示

変更ファイルは src/routes/+layout.svelte のみ(style.scss には触れていません)。

## 検証

- npm run build / npm run check / npm run lint 全通過
- npm run preview + curl で / と /yabumi の両ページにフッターとユーティリティバーが含まれることを確認

Closes #36
Closes #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CstqXvSDoZrhAMXGmfzdeD