### PR TITLE
レスポンシブ整理と官公庁様式化（横スクロール解消・角丸廃止・注記・パンくず）

### DIFF
--- a/src/routes/+error.svelte
+++ b/src/routes/+error.svelte
@@ -7,11 +7,13 @@ import { page } from "$app/stores";
   >
 </div>
 
-<div class="row max-width mx-auto text-center mt-5">
-  <div class="fs-1">{$page.status}</div>
-  <div class="fs-3">{$page.status === 404 ? "Not Found" : "Error"}</div>
-  <div class="mt-4">
-    {$page.error?.message ?? "エラーが発生しました"}
+<div class="max-width mx-auto container">
+  <div class="row text-center mt-5">
+    <div class="fs-1">{$page.status}</div>
+    <div class="fs-3">{$page.status === 404 ? "Not Found" : "Error"}</div>
+    <div class="mt-4">
+      {$page.error?.message ?? "エラーが発生しました"}
+    </div>
   </div>
 </div>
 

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -9,8 +9,8 @@ const showMigrationNotice =
 </script>
 
 <div class="bg-main text-center py-2">
-  <div class="fs-1">野洲田川水系</div>
-  <div class="fs-3 mt-2">定点観測所</div>
+  <div class="fs-1">野洲田川水系 定点観測所</div>
+  <div class="fs-5">―リアルタイム流速情報―</div>
 </div>
 {#if showMigrationNotice}
   <div class="max-width mx-auto px-3">

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -26,7 +26,8 @@ const showMigrationNotice =
     </div>
   </div>
 {/if}
-<div class="row max-width mx-auto pt-3">
+<div class="max-width mx-auto container pt-3">
+<div class="row">
   <div class="col-12">
     このサイトは Nostr 日本リレーの流速をグラフ表示化しています。<br />
     流速ちゃんがリレー上に投稿したKind 30078 をデータベースとしたシステムで、nostr-key-value
@@ -59,7 +60,7 @@ const showMigrationNotice =
             <td class="py-md-3">
               <a href="/{relay.key}" class="text-primary">{relay.river_name}</a>
             </td>
-            <td>
+            <td class="uri-cell">
               {relay.relay_url}
             </td>
           </tr>
@@ -122,6 +123,7 @@ const showMigrationNotice =
   </div>
   <div class="p-4"></div>
 </div>
+</div>
 
 <style>
   .migration-notice {
@@ -138,5 +140,14 @@ const showMigrationNotice =
     border: 1px solid #000;
     text-align: center;
     height: 1.5rem;
+  }
+  .uri-cell {
+    word-break: break-all;
+  }
+  /* モバイルでは大見出しを一段階（fs-2 相当に）縮小する */
+  @media (max-width: 575.98px) {
+    .fs-1 {
+      font-size: calc(1.325rem + 0.9vw) !important;
+    }
   }
 </style>

--- a/src/routes/[relay]/+page.svelte
+++ b/src/routes/[relay]/+page.svelte
@@ -149,6 +149,13 @@ const selectDate = () => {
   >
 </div>
 
+<div class="max-width mx-auto container py-1">
+  <nav class="breadcrumb-list" aria-label="パンくずリスト">
+    <a href="/">トップ</a>
+    &gt; 野洲田川水系 &gt; {info.river_name}観測所
+  </nav>
+</div>
+
 <div class="bg-light-sub">
   <div
     class="max-width mx-auto d-md-flex justify-content-between align-items-bottom pb-3 container flex-row-reverse"
@@ -265,5 +272,12 @@ const selectDate = () => {
   .data-note {
     font-size: 11px;
     color: #666;
+  }
+  .breadcrumb-list {
+    font-size: 11px;
+  }
+  .breadcrumb-list a {
+    text-decoration: underline;
+    color: #0b346e;
   }
 </style>

--- a/src/routes/[relay]/+page.svelte
+++ b/src/routes/[relay]/+page.svelte
@@ -248,11 +248,22 @@ const selectDate = () => {
   </div>
 {/if}
 
+<div class="max-width mx-auto container mt-3 mb-4">
+  <div class="data-note">
+    このデータは速報値であり、後日修正されることがあります。<br />
+    観測は毎分、表示は10分毎の集計値です。ページは5分毎に自動更新されます。
+  </div>
+</div>
+
 <style>
   a {
     text-decoration: none;
   }
   .select-sector input {
     vertical-align: middle;
+  }
+  .data-note {
+    font-size: 11px;
+    color: #666;
   }
 </style>

--- a/src/routes/[relay]/+page.svelte
+++ b/src/routes/[relay]/+page.svelte
@@ -252,13 +252,7 @@ const selectDate = () => {
   a {
     text-decoration: none;
   }
-  .select-sector {
-    border-radius: 10px 10px 0 0;
-  }
   .select-sector input {
     vertical-align: middle;
-  }
-  .head-sub-title {
-    border-radius: 0 0 10px 10px;
   }
 </style>

--- a/src/routes/[relay]/+page.svelte
+++ b/src/routes/[relay]/+page.svelte
@@ -210,33 +210,41 @@ const selectDate = () => {
     <BaseInfo {info} {operation} />
   </div>
   <div class="p-2"></div>
-  <div class="row max-width mx-auto">
-    <div class="col-12 col-md-3 order-2">
-      <DataTable {axis} data={counts} />
-    </div>
-    <div class="col-12 col-md-9 order-1">
-      <Charts {axis} data={counts} />
+  <div class="max-width mx-auto container">
+    <div class="row">
+      <div class="col-12 col-md-3 order-2">
+        <DataTable {axis} data={counts} />
+      </div>
+      <div class="col-12 col-md-9 order-1">
+        <Charts {axis} data={counts} />
+      </div>
     </div>
   </div>
 {:else if status === "nodata"}
-  <div class="row max-width mx-auto text-center mt-5">
-    <div class="fs-1"></div>
-    <div class="fs-3">No Data</div>
-    <div class="mt-4">指定日の観測データがありません</div>
+  <div class="max-width mx-auto container text-center mt-5">
+    <div class="row">
+      <div class="fs-1"></div>
+      <div class="fs-3">No Data</div>
+      <div class="mt-4">指定日の観測データがありません</div>
+    </div>
   </div>
 {:else if status === "error"}
-  <div class="row max-width mx-auto text-center mt-5">
-    <div class="fs-1"></div>
-    <div class="fs-3">Error</div>
-    <div class="mt-4">
-      データを取得できませんでした。時間をおいて再読み込みしてください
+  <div class="max-width mx-auto container text-center mt-5">
+    <div class="row">
+      <div class="fs-1"></div>
+      <div class="fs-3">Error</div>
+      <div class="mt-4">
+        データを取得できませんでした。時間をおいて再読み込みしてください
+      </div>
     </div>
   </div>
 {:else}
-  <div class="row max-width mx-auto text-center mt-5">
-    <div class="fs-1"></div>
-    <div class="fs-3">Now loading...</div>
-    <div class="mt-4">読み込み中</div>
+  <div class="max-width mx-auto container text-center mt-5">
+    <div class="row">
+      <div class="fs-1"></div>
+      <div class="fs-3">Now loading...</div>
+      <div class="mt-4">読み込み中</div>
+    </div>
   </div>
 {/if}
 


### PR DESCRIPTION
## 概要

モバイル表示の崩れ解消と、官公庁の水位観測サイト風デザインへの様式統一を行いました。

Closes #33
Closes #37
Closes #35
Refs #38

## 変更内容

### #33 モバイル横スクロールの解消
- パディングを持つ親なしで直置きされていた Bootstrap `.row`（トップ1箇所・観測所ページ4箇所）を `max-width mx-auto container` のラッパーで包み、ネガティブマージンによる 320〜960px での横スクロールを解消
- トップのリレー一覧テーブルの URI セル（wss://〜）に `word-break: break-all` を追加し、狭い画面での表はみ出しを防止
- トップの `fs-1` 見出しをモバイル（575.98px 以下）で一段階（fs-2 相当に）縮小

### #37 角丸廃止・見出し様式の官公庁化
- 観測所ページの `.select-sector` / `.head-sub-title` の border-radius を削除（直角に）
- トップページ見出しを官公庁様式の一行「野洲田川水系 定点観測所」+ 直下に小さめの「―リアルタイム流速情報―」へ変更（紺帯 bg-main は維持）

### #35 注記文言の追加
- 観測所ページのグラフ・表エリアの下に小さめグレーの注記を追加
  - 「このデータは速報値であり、後日修正されることがあります。」
  - 「観測は毎分、表示は10分毎の集計値です。ページは5分毎に自動更新されます。」

### #38 パンくずリスト（部分対応）
- 観測所ページのヘッダー下に「トップ &gt; 野洲田川水系 &gt; ○○川観測所」のパンくずを追加（「トップ」のみ / へリンク）

## 検証

- `npm run build` / `npm run check` / `npm run lint` 全通過（各コミットごと）
- `npm run preview` の SSR HTML で、全ページの `.row` の親に `.container`（横パディング 0.75rem）があること、パンくず・注記・新見出しの出力、border-radius の消失を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CstqXvSDoZrhAMXGmfzdeD