### PR TITLE
観測所ページの整列改善（操作バー統合・高さ揃え・諸元表整理）

### DIFF
--- a/src/components/baseinfo.svelte
+++ b/src/components/baseinfo.svelte
@@ -23,9 +23,9 @@ $: specRows = [
   { label: "水系名", value: "野洲田川水系" },
   { label: "河川名", value: info.river_name },
   { label: "観測所", value: "野洲田川定点観測所" },
-  { label: "所在地", value: info.relay_url },
+  { label: "所在地", value: info.relay_url, className: "spec-url" },
   { label: "観測項目", value: "流速（投稿数）" },
-  { label: "観測方式", value: "テレメータ（自動観測・毎分）" },
+  { label: "観測方式", value: "テレメータ（自動観測・毎分）", className: "spec-wrap" },
   { label: "ライブカメラ", value: info.live_cam ? "○" : "✕" },
   { label: "観測システム", value: "流速ちゃん", link: systemUrl },
   {
@@ -107,11 +107,27 @@ $: specRows = [
   .spec-wide-container {
     display: none;
   }
-  /* 見出しは折り返さず、値セルは折り返して 960px 幅に収める */
-  .spec-table-wide th {
-    white-space: nowrap;
-  }
+  /* 見出しと短い値は折り返さず、長い値（所在地の URL・観測方式）だけ
+     折り返しを許可して 960px 幅に収める */
+  .spec-table-wide th,
   .spec-table-wide td {
+    white-space: nowrap;
+    padding-left: 5px;
+    padding-right: 5px;
+  }
+  .spec-table-wide td.spec-url,
+  .spec-table-wide td.spec-wrap {
+    white-space: normal;
+  }
+  /* 標準的な値なら1行で収まる幅を確保（長いリレーURLのみ折り返す） */
+  .spec-table-wide td.spec-url {
+    min-width: 8.5em;
+  }
+  .spec-table-wide td.spec-wrap {
+    min-width: 15em;
+  }
+  .spec-table-wide td.spec-url,
+  .spec-table-narrow td.spec-url {
     word-break: break-all;
   }
   .spec-table-narrow th {

--- a/src/components/datatable.svelte
+++ b/src/components/datatable.svelte
@@ -30,6 +30,7 @@ function buildRows(axis: number[], data: number[]): Row[] {
 $: formatted = buildRows(axis, data);
 </script>
 
+<div class="datatable-root">
 <div class="table-label">
   <span>観測値</span>
   <span class="unit-note">(単位: 投稿/10分)</span>
@@ -64,6 +65,7 @@ $: formatted = buildRows(axis, data);
     </tbody>
   </table>
 </div>
+</div>
 
 <style>
   .table-container {
@@ -72,9 +74,21 @@ $: formatted = buildRows(axis, data);
     font-size: 12px;
     border: 1px solid #000;
   }
+  /* PC ではグラフ列の高さに合わせて表を収め、表内でスクロールさせる */
   @media (min-width: 768px) {
+    .datatable-root {
+      position: absolute;
+      top: 0;
+      bottom: 0;
+      left: 0.75rem;
+      right: 0.75rem;
+      display: flex;
+      flex-direction: column;
+    }
     .table-container {
-      height: 60vh;
+      flex: 1 1 auto;
+      min-height: 0;
+      height: auto;
     }
   }
 

--- a/src/routes/[relay]/+page.svelte
+++ b/src/routes/[relay]/+page.svelte
@@ -156,34 +156,18 @@ const selectDate = () => {
   </nav>
 </div>
 
-<div class="bg-light-sub">
-  <div
-    class="max-width mx-auto d-md-flex justify-content-between align-items-bottom pb-3 container flex-row-reverse"
-  >
-    <div class="bg-main py-2 px-3 head-sub-title">
-      Nostr 日本語リレーリアルタイム流速検出システム
-    </div>
-    <div class="pt-2">{info.relay_url}</div>
+<div class="max-width mx-auto container">
+  <div class="station-title">
+    {info.river_name}観測所
+    <span class="station-uri">（{info.relay_url}）</span>
   </div>
+  <div class="station-sub">Nostr 日本語リレー リアルタイム流速検出システム</div>
 </div>
-{#if info}
-  <div class="bg-light-sub">
-    <div
-      class="max-width mx-auto d-md-flex justify-content-between align-items-center container flex-row-reverse pt-2"
-    >
-      <div class="">
-        日付を選択：
-        <input
-          type="date"
-          class=""
-          bind:value={selectedDate}
-          on:change={selectDate}
-        />
-        {#if data.date === null && lastUpdated}
-          <div class="text-end">最終更新: {format(lastUpdated, "HH:mm")}</div>
-        {/if}
-      </div>
-      <div class="select-sector pt-2 pb-1 px-3 bg-white mt-2">
+
+<div class="bg-light-sub py-2 mt-2">
+  <div class="max-width mx-auto container">
+    <div class="control-bar">
+      <span class="control-group">
         <label for="mode-current" class="me-2">
           <input
             type="radio"
@@ -206,10 +190,19 @@ const selectDate = () => {
           />
           日付指定
         </label>
-      </div>
+      </span>
+      <span class="control-group">
+        日付を選択：
+        <input type="date" bind:value={selectedDate} on:change={selectDate} />
+      </span>
+      {#if data.date === null && lastUpdated}
+        <span class="control-group ms-md-auto">
+          最終更新: {format(lastUpdated, "HH:mm")}
+        </span>
+      {/if}
     </div>
   </div>
-{/if}
+</div>
 <div class="p-2"></div>
 
 {#if status === "ready" && axis && counts}
@@ -219,7 +212,7 @@ const selectDate = () => {
   <div class="p-2"></div>
   <div class="max-width mx-auto container">
     <div class="row">
-      <div class="col-12 col-md-3 order-2">
+      <div class="col-12 col-md-3 order-2 position-relative">
         <DataTable {axis} data={counts} />
       </div>
       <div class="col-12 col-md-9 order-1">
@@ -266,7 +259,32 @@ const selectDate = () => {
   a {
     text-decoration: none;
   }
-  .select-sector input {
+  .station-title {
+    font-size: 18px;
+    font-weight: bold;
+    border-left: 5px solid #0b346e;
+    border-bottom: 1px solid #0b346e;
+    padding: 2px 8px;
+    margin-top: 0.25rem;
+  }
+  .station-uri {
+    font-size: 12px;
+    font-weight: normal;
+    word-break: break-all;
+  }
+  .station-sub {
+    font-size: 11px;
+    color: #666;
+    padding-left: 13px;
+    margin-top: 2px;
+  }
+  .control-bar {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 0.25rem 1.5rem;
+  }
+  .control-bar input[type="radio"] {
     vertical-align: middle;
   }
   .data-note {


### PR DESCRIPTION
Closes #46

## 内容
観測所ページの「不揃い感」を解消する整列改善。

1. **ヘッダー操作部の一列化**: バラバラに配置されていたリレーURI・システム名バッジ・日付選択・現在/日付指定ラジオ・最終更新を再構成。「○○川観測所（URI）」の観測所見出し + 1本のコントロールバー（左: 表示モード・日付、右端: 最終更新）に統合
2. **グラフと観測値表の高さ揃え**: PC で観測値表をグラフ列の高さに合わせ、下端を揃えて表内スクロールに（グラフ下の大きな空白を解消）。モバイルは従来どおり
3. **諸元表の折返し整理**: 「やぶみ/川」「wss://yabu.m/e」等の不自然な折返しの原因（全セル break-all）を解消。標準的な値は1行、長いリレーURLのみ折返し

## ベースブランチについて
#45（トップページ官公庁化）の上に積んでいます。**#45 を先にマージしてください**（ブランチ削除でマージすれば本PRのベースは自動で develop に切り替わります）。

## 確認
- スクリーンショット（375px / 1280px、やぶみ川・きりの川）で崩れなしを確認
- `npm run build` ✅ / `npm run check` 0 errors ✅ / `npm run lint` エラー0 ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CstqXvSDoZrhAMXGmfzdeD