### PR TITLE
リリース: 官公庁様式化・レスポンシブ整理一式

### DIFF
--- a/src/components/baseinfo.svelte
+++ b/src/components/baseinfo.svelte
@@ -23,6 +23,9 @@ $: specRows = [
   { label: "水系名", value: "野洲田川水系" },
   { label: "河川名", value: info.river_name },
   { label: "観測所", value: "野洲田川定点観測所" },
+  { label: "所在地", value: info.relay_url },
+  { label: "観測項目", value: "流速（投稿数）" },
+  { label: "観測方式", value: "テレメータ（自動観測・毎分）" },
   { label: "ライブカメラ", value: info.live_cam ? "○" : "✕" },
   { label: "観測システム", value: "流速ちゃん", link: systemUrl },
   {

--- a/src/components/baseinfo.svelte
+++ b/src/components/baseinfo.svelte
@@ -8,38 +8,79 @@ const operationClasses = {
   欠測: "text-danger",
   過去ログ: "text-secondary",
 } as const;
+
+const systemUrl =
+  "https://nostx.shino3.net/npub150qnaaxfan8auqdajvn292cgk2khm3tl8dmakamj878z44a6yntqk7uktv";
+
+type SpecRow = {
+  label: string;
+  value: string;
+  link?: string;
+  className?: string;
+};
+
+$: specRows = [
+  { label: "水系名", value: "野洲田川水系" },
+  { label: "河川名", value: info.river_name },
+  { label: "観測所", value: "野洲田川定点観測所" },
+  { label: "ライブカメラ", value: info.live_cam ? "○" : "✕" },
+  { label: "観測システム", value: "流速ちゃん", link: systemUrl },
+  {
+    label: "稼働状況",
+    value: operation,
+    className: operationClasses[operation],
+  },
+] satisfies SpecRow[];
 </script>
 
-<table>
-  <thead>
-    <tr class="bg-sub">
-      <th><span>水系名</span></th>
-      <th><span>河川名</span></th>
-      <th><span>観測所</span></th>
-      <th><span>ライブカメラ</span></th>
-      <th><span>観測システム</span></th>
-      <th><span>稼働状況</span></th>
-    </tr>
-  </thead>
+<!-- md 以上: 見出し行 + 値行の横並び表 -->
+<div class="spec-wide-container">
+  <table class="spec-table spec-table-wide">
+    <thead>
+      <tr class="bg-sub">
+        {#each specRows as row}
+          <th>{row.label}</th>
+        {/each}
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        {#each specRows as row}
+          <td class={row.className ?? ""}>
+            {#if row.link}
+              <a href={row.link} class="text-primary" target="_blank" rel="noopener noreferrer"
+                >{row.value}</a
+              >
+            {:else}
+              {row.value}
+            {/if}
+          </td>
+        {/each}
+      </tr>
+    </tbody>
+  </table>
+</div>
+
+<!-- md 未満: 「項目 | 値」の2列縦表 -->
+<table class="spec-table spec-table-narrow">
   <tbody>
-    <tr>
-      <td><span>野洲田川水系</span></td>
-      <td><span>{info.river_name}</span></td>
-      <td><span>野洲田川定点観測所</span></td>
-      <td><span>{info.live_cam ? "○" : "✕"}</span></td>
-      <td
-        ><span
-          ><a
-            href="https://nostx.shino3.net/npub150qnaaxfan8auqdajvn292cgk2khm3tl8dmakamj878z44a6yntqk7uktv"
-            class="text-primary"
-            target="_blank" rel="noopener noreferrer">流速ちゃん</a
-          ></span
-        ></td
-      >
-      <td class={operationClasses[operation]}><span>{operation}</span></td>
-    </tr>
+    {#each specRows as row}
+      <tr>
+        <th class="bg-sub" scope="row">{row.label}</th>
+        <td class={row.className ?? ""}>
+          {#if row.link}
+            <a href={row.link} class="text-primary" target="_blank" rel="noopener noreferrer"
+              >{row.value}</a
+            >
+          {:else}
+            {row.value}
+          {/if}
+        </td>
+      </tr>
+    {/each}
   </tbody>
 </table>
+
 {#if info.live_cam}
   <div class="text-end mt-2">
     <a href={info.live_cam_url} target="_blank" rel="noopener noreferrer" class="text-danger"
@@ -49,27 +90,38 @@ const operationClasses = {
 {/if}
 
 <style>
-  table {
+  .spec-table {
     width: 100%;
     border: 1px solid #000;
-    writing-mode: vertical-lr;
   }
-  @media (min-width: 768px) {
-    table {
-      -ms-writing-mode: initial;
-      writing-mode: initial;
-    }
-  }
-  td,
-  th {
+  .spec-table td,
+  .spec-table th {
     padding: 2px 7px;
     border: 1px solid #000;
     text-align: center;
     height: 1.5rem;
   }
-  td > span,
-  th > span {
-    writing-mode: horizontal-tb;
+  .spec-wide-container {
+    display: none;
+  }
+  .spec-table-wide td,
+  .spec-table-wide th {
     white-space: nowrap;
+  }
+  .spec-table-narrow th {
+    width: 40%;
+    white-space: nowrap;
+  }
+  .spec-table-narrow td {
+    word-break: break-all;
+  }
+  @media (min-width: 768px) {
+    .spec-wide-container {
+      display: block;
+      overflow-x: auto;
+    }
+    .spec-table-narrow {
+      display: none;
+    }
   }
 </style>

--- a/src/components/baseinfo.svelte
+++ b/src/components/baseinfo.svelte
@@ -107,9 +107,12 @@ $: specRows = [
   .spec-wide-container {
     display: none;
   }
-  .spec-table-wide td,
+  /* 見出しは折り返さず、値セルは折り返して 960px 幅に収める */
   .spec-table-wide th {
     white-space: nowrap;
+  }
+  .spec-table-wide td {
+    word-break: break-all;
   }
   .spec-table-narrow th {
     width: 40%;

--- a/src/components/baseinfo.svelte
+++ b/src/components/baseinfo.svelte
@@ -23,9 +23,9 @@ $: specRows = [
   { label: "水系名", value: "野洲田川水系" },
   { label: "河川名", value: info.river_name },
   { label: "観測所", value: "野洲田川定点観測所" },
-  { label: "所在地", value: info.relay_url },
+  { label: "所在地", value: info.relay_url, className: "spec-url" },
   { label: "観測項目", value: "流速（投稿数）" },
-  { label: "観測方式", value: "テレメータ（自動観測・毎分）" },
+  { label: "観測方式", value: "テレメータ（自動観測・毎分）", className: "spec-wrap" },
   { label: "ライブカメラ", value: info.live_cam ? "○" : "✕" },
   { label: "観測システム", value: "流速ちゃん", link: systemUrl },
   {
@@ -107,11 +107,27 @@ $: specRows = [
   .spec-wide-container {
     display: none;
   }
-  /* 見出しは折り返さず、値セルは折り返して 960px 幅に収める */
-  .spec-table-wide th {
-    white-space: nowrap;
-  }
+  /* 見出しと短い値は折り返さず、長い値（所在地の URL・観測方式）だけ
+     折り返しを許可して 960px 幅に収める */
+  .spec-table-wide th,
   .spec-table-wide td {
+    white-space: nowrap;
+    padding-left: 5px;
+    padding-right: 5px;
+  }
+  .spec-table-wide td.spec-url,
+  .spec-table-wide td.spec-wrap {
+    white-space: normal;
+  }
+  /* 標準的な値なら1行で収まる幅を確保（長いリレーURLのみ折り返す） */
+  .spec-table-wide td.spec-url {
+    min-width: 8.5em;
+  }
+  .spec-table-wide td.spec-wrap {
+    min-width: 15em;
+  }
+  .spec-table-wide td.spec-url,
+  .spec-table-narrow td.spec-url {
     word-break: break-all;
   }
   .spec-table-narrow th {

--- a/src/components/charts.svelte
+++ b/src/components/charts.svelte
@@ -14,6 +14,7 @@ import {
 import "chartjs-adapter-date-fns";
 import { fromUnixTime } from "date-fns";
 import { onDestroy, onMount } from "svelte";
+import { FLOW_LEVELS } from "$lib/config";
 export let axis: number[];
 export let data: number[];
 
@@ -44,6 +45,9 @@ const movingAverage = (values: number[], windowSize: number): number[] =>
     return sum / windowSize;
   });
 
+// 流速水準線(ツールチップには表示しない)
+const LEVEL_LINE_LABELS = ["流速注意水準", "氾濫危険水準"];
+
 const buildChartData = (axis: number[], data: number[]) => ({
   labels: axis.map((item) => fromUnixTime(item)),
   datasets: [
@@ -54,6 +58,22 @@ const buildChartData = (axis: number[], data: number[]) => ({
       cubicInterpolationMode: "monotone" as const,
       borderColor: "#113285",
       borderWidth: 1.2,
+      pointStyle: false as const,
+    },
+    {
+      type: "line" as const,
+      label: "流速注意水準",
+      data: axis.map(() => FLOW_LEVELS.attention),
+      borderColor: "#d4a017",
+      borderWidth: 1.5,
+      pointStyle: false as const,
+    },
+    {
+      type: "line" as const,
+      label: "氾濫危険水準",
+      data: axis.map(() => FLOW_LEVELS.danger),
+      borderColor: "#dc3545",
+      borderWidth: 1.5,
       pointStyle: false as const,
     },
     {
@@ -77,6 +97,12 @@ onMount(() => {
       animation: false,
       responsive: true,
       maintainAspectRatio: false,
+      plugins: {
+        tooltip: {
+          filter: (item) =>
+            !LEVEL_LINE_LABELS.includes(item.dataset.label ?? ""),
+        },
+      },
       scales: {
         x: {
           type: "time",
@@ -92,6 +118,7 @@ onMount(() => {
           },
         },
         y: {
+          suggestedMax: FLOW_LEVELS.danger * 1.1,
           title: {
             display: true,
             text: "投稿数 (posts/10min)",

--- a/src/components/charts.svelte
+++ b/src/components/charts.svelte
@@ -76,7 +76,7 @@ onMount(() => {
     options: {
       animation: false,
       responsive: true,
-      aspectRatio: 1,
+      maintainAspectRatio: false,
       scales: {
         x: {
           type: "time",
@@ -109,26 +109,18 @@ onDestroy(() => {
 </script>
 
 <div class="mx-auto chart_size">
-  <canvas bind:this={chartCanvas} class="img-fluid canvas"></canvas>
+  <canvas bind:this={chartCanvas}></canvas>
 </div>
 
 <style>
-  .canvas {
-    min-width: 300px;
-    min-height: 300px;
-    width: 85vw;
-    height: 85vw;
-  }
   .chart_size {
-    min-width: 300px;
-    min-height: 300px;
-    width: 85vw;
-    height: 85vw;
+    position: relative;
+    width: 100%;
+    aspect-ratio: 2 / 1;
   }
-  @media (min-width: 768px) {
+  @media (max-width: 767px) {
     .chart_size {
-      width: 100%;
-      height: initial;
+      aspect-ratio: 4 / 3;
     }
   }
 </style>

--- a/src/components/datatable.svelte
+++ b/src/components/datatable.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 import { format, fromUnixTime, isSameDay, isSameHour } from "date-fns";
+import { FLOW_LEVELS } from "$lib/config";
 export let axis: number[];
 export let data: number[];
 type Row = {
@@ -29,7 +30,10 @@ function buildRows(axis: number[], data: number[]): Row[] {
 $: formatted = buildRows(axis, data);
 </script>
 
-<span>測位情報 (posts / 10min)</span>
+<div class="table-label">
+  <span>観測値</span>
+  <span class="unit-note">(単位: 投稿/10分)</span>
+</div>
 <div class="table-container">
   <table>
     <thead class="sticky-top">
@@ -50,7 +54,11 @@ $: formatted = buildRows(axis, data);
             >{#if item.showTime}{format(item.date, "HH")}{/if}</td
           >
           <td>{format(item.date, "mm")}</td>
-          <td class="text-end no-border-left">{item.count}</td>
+          <td
+            class="text-end no-border-left"
+            class:level-attention={item.count >= FLOW_LEVELS.attention}
+            class:level-danger={item.count >= FLOW_LEVELS.danger}>{item.count}</td
+          >
         </tr>
       {/each}
     </tbody>
@@ -81,6 +89,20 @@ $: formatted = buildRows(axis, data);
   }
   .no-border-left {
     border-left: solid 1px #000;
+  }
+  .table-label {
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+  }
+  .unit-note {
+    font-size: 12px;
+  }
+  .level-attention {
+    background-color: #fff3cd;
+  }
+  .level-danger {
+    background-color: #f8d7da;
   }
   table {
     width: 100%;

--- a/src/components/datatable.svelte
+++ b/src/components/datatable.svelte
@@ -30,6 +30,7 @@ function buildRows(axis: number[], data: number[]): Row[] {
 $: formatted = buildRows(axis, data);
 </script>
 
+<div class="datatable-root">
 <div class="table-label">
   <span>観測値</span>
   <span class="unit-note">(単位: 投稿/10分)</span>
@@ -64,6 +65,7 @@ $: formatted = buildRows(axis, data);
     </tbody>
   </table>
 </div>
+</div>
 
 <style>
   .table-container {
@@ -72,9 +74,21 @@ $: formatted = buildRows(axis, data);
     font-size: 12px;
     border: 1px solid #000;
   }
+  /* PC ではグラフ列の高さに合わせて表を収め、表内でスクロールさせる */
   @media (min-width: 768px) {
+    .datatable-root {
+      position: absolute;
+      top: 0;
+      bottom: 0;
+      left: 0.75rem;
+      right: 0.75rem;
+      display: flex;
+      flex-direction: column;
+    }
     .table-container {
-      height: 60vh;
+      flex: 1 1 auto;
+      min-height: 0;
+      height: auto;
     }
   }
 

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -80,3 +80,17 @@ export const FLOW_LEVELS: FlowLevels = {
   attention: 100,
   danger: 200,
 };
+
+// トップページの「お知らせ」欄（新しいものを先頭に）
+export type Notice = {
+  date: string;
+  text: string;
+  url?: string;
+};
+
+export const notices: Notice[] = [
+  {
+    date: "2026-07-04",
+    text: "当観測所は https://nostr-flowmeter.shino3.net/ へ移転しました。",
+  },
+];

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -70,7 +70,7 @@ export const getRelay = (key: string): RelayItem | undefined => {
   return relays.find((item) => item.key === key);
 };
 
-// 流速水準(官公庁の水位基準風、単位: posts/10min)。プレビュー後に調整可
+// 流速水準（官公庁の水位基準風、単位: posts/10min）。プレビュー後に調整可
 export type FlowLevels = {
   attention: number;
   danger: number;

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -69,3 +69,14 @@ export const relays: Relays = [
 export const getRelay = (key: string): RelayItem | undefined => {
   return relays.find((item) => item.key === key);
 };
+
+// 流速水準（官公庁の水位基準風、単位: posts/10min）。プレビュー後に調整可
+export type FlowLevels = {
+  attention: number;
+  danger: number;
+};
+
+export const FLOW_LEVELS: FlowLevels = {
+  attention: 100,
+  danger: 200,
+};

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -69,3 +69,14 @@ export const relays: Relays = [
 export const getRelay = (key: string): RelayItem | undefined => {
   return relays.find((item) => item.key === key);
 };
+
+// 流速水準(官公庁の水位基準風、単位: posts/10min)。プレビュー後に調整可
+export type FlowLevels = {
+  attention: number;
+  danger: number;
+};
+
+export const FLOW_LEVELS: FlowLevels = {
+  attention: 100,
+  danger: 200,
+};

--- a/src/routes/+error.svelte
+++ b/src/routes/+error.svelte
@@ -7,11 +7,13 @@ import { page } from "$app/stores";
   >
 </div>
 
-<div class="row max-width mx-auto text-center mt-5">
-  <div class="fs-1">{$page.status}</div>
-  <div class="fs-3">{$page.status === 404 ? "Not Found" : "Error"}</div>
-  <div class="mt-4">
-    {$page.error?.message ?? "エラーが発生しました"}
+<div class="max-width mx-auto container">
+  <div class="row text-center mt-5">
+    <div class="fs-1">{$page.status}</div>
+    <div class="fs-3">{$page.status === 404 ? "Not Found" : "Error"}</div>
+    <div class="mt-4">
+      {$page.error?.message ?? "エラーが発生しました"}
+    </div>
   </div>
 </div>
 

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,11 +1,54 @@
-<script>
+<script lang="ts">
 import "../styles/style.scss";
+import { onMount } from "svelte";
+import { browser } from "$app/environment";
 import { page } from "$app/stores";
 import { getRelay } from "$lib/config";
 
 $: river_name = $page.params.relay
   ? "（" + getRelay($page.params.relay)?.river_name + "）"
   : "";
+
+type FontSize = "small" | "normal" | "large";
+
+const FONT_SIZE_KEY = "fontSize";
+let fontSize: FontSize = "normal";
+
+function applyFontSize(size: FontSize): void {
+  if (!browser) return;
+  document.body.classList.remove("fs-small", "fs-large");
+  if (size === "small") document.body.classList.add("fs-small");
+  if (size === "large") document.body.classList.add("fs-large");
+}
+
+function setFontSize(size: FontSize): void {
+  if (!browser) return;
+  fontSize = size;
+  applyFontSize(size);
+  try {
+    localStorage.setItem(FONT_SIZE_KEY, size);
+  } catch {
+    // localStorage が使えない環境では保存しない
+  }
+}
+
+function printPage(): void {
+  if (!browser) return;
+  window.print();
+}
+
+onMount(() => {
+  let saved: string | null = null;
+  try {
+    saved = localStorage.getItem(FONT_SIZE_KEY);
+  } catch {
+    saved = null;
+  }
+  if (saved === "small" || saved === "normal" || saved === "large") {
+    fontSize = saved;
+    applyFontSize(saved);
+  }
+});
 </script>
 
 <svelte:head>
@@ -17,6 +60,35 @@ $: river_name = $page.params.relay
   <meta property="og:url" content={$page.url.href}>
   <meta name="twitter:card" content="summary">
 </svelte:head>
+
+<div class="utility-bar">
+  <div class="utility-bar-inner max-width">
+    <span class="utility-label">文字サイズ:</span>
+    <button
+      type="button"
+      class="utility-btn"
+      class:active={fontSize === "small"}
+      on:click={() => setFontSize("small")}>小</button
+    >
+    <span class="utility-sep">|</span>
+    <button
+      type="button"
+      class="utility-btn"
+      class:active={fontSize === "normal"}
+      on:click={() => setFontSize("normal")}>標準</button
+    >
+    <span class="utility-sep">|</span>
+    <button
+      type="button"
+      class="utility-btn"
+      class:active={fontSize === "large"}
+      on:click={() => setFontSize("large")}>大</button
+    >
+    <button type="button" class="utility-btn utility-print" on:click={printPage}
+      >印刷用表示</button
+    >
+  </div>
+</div>
 
 <slot />
 
@@ -49,6 +121,67 @@ $: river_name = $page.params.relay
 </footer>
 
 <style>
+  :global(body.fs-small) {
+    font-size: 11px;
+  }
+
+  :global(body.fs-large) {
+    font-size: 15px;
+  }
+
+  .utility-bar {
+    background-color: #f2f2f2;
+    border-bottom: 1px solid #ddd;
+  }
+
+  .utility-bar-inner {
+    margin: 0 auto;
+    padding: 2px 16px;
+    text-align: right;
+    font-size: 11px;
+    color: #333;
+  }
+
+  .utility-label {
+    margin-right: 4px;
+  }
+
+  .utility-sep {
+    color: #999;
+  }
+
+  .utility-btn {
+    background: none;
+    border: none;
+    border-radius: 0;
+    padding: 1px 4px;
+    font-size: 11px;
+    color: #333;
+    cursor: pointer;
+    text-decoration: underline;
+  }
+
+  .utility-btn.active {
+    font-weight: bold;
+    text-decoration: none;
+    background-color: #0b346e;
+    color: #fff;
+  }
+
+  .utility-print {
+    margin-left: 16px;
+  }
+
+  @media print {
+    .utility-bar {
+      display: none;
+    }
+
+    .footer-links {
+      display: none;
+    }
+  }
+
   .site-footer {
     margin-top: 48px;
     background-color: #0b346e;

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -19,3 +19,86 @@ $: river_name = $page.params.relay
 </svelte:head>
 
 <slot />
+
+<footer class="site-footer">
+  <div class="site-footer-inner max-width">
+    <div class="footer-links">
+      <h2 class="footer-heading">関係機関リンク</h2>
+      <ul class="footer-link-list">
+        <li>
+          <a
+            href="https://nostx.shino3.net/npub150qnaaxfan8auqdajvn292cgk2khm3tl8dmakamj878z44a6yntqk7uktv"
+            target="_blank"
+            rel="noopener noreferrer">流速ちゃん</a
+          >
+        </li>
+        <li>
+          <a
+            href="https://github.com/ShinoharaTa/nostr-flowmeter-site"
+            target="_blank"
+            rel="noopener noreferrer">ページソース（GitHub）</a
+          >
+        </li>
+      </ul>
+    </div>
+    <p class="footer-operator">運営: 野洲田川定点観測所（サイト管理者: shino3）</p>
+    <p class="footer-copyright">
+      Copyright &copy; 野洲田川定点観測所 All Rights Reserved.
+    </p>
+  </div>
+</footer>
+
+<style>
+  .site-footer {
+    margin-top: 48px;
+    background-color: #0b346e;
+    color: #fff;
+    border-radius: 0;
+  }
+
+  .site-footer-inner {
+    margin: 0 auto;
+    padding: 24px 16px 12px;
+  }
+
+  .footer-heading {
+    font-size: 14px;
+    font-weight: bold;
+    margin: 0 0 8px;
+    padding-left: 8px;
+    border-left: 4px solid #fff;
+  }
+
+  .footer-link-list {
+    list-style: none;
+    margin: 0 0 16px;
+    padding: 0;
+  }
+
+  .footer-link-list li {
+    display: inline-block;
+    margin-right: 24px;
+  }
+
+  .footer-link-list a {
+    color: #cfe0f5;
+    text-decoration: underline;
+  }
+
+  .footer-link-list a:hover {
+    color: #fff;
+  }
+
+  .footer-operator {
+    margin: 0 0 16px;
+    font-size: 12px;
+  }
+
+  .footer-copyright {
+    margin: 0;
+    padding: 8px 0;
+    border-top: 1px solid #3a5a92;
+    font-size: 11px;
+    text-align: center;
+  }
+</style>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,11 +1,66 @@
 <script lang="ts">
+import { format, fromUnixTime } from "date-fns";
 import { browser } from "$app/environment";
-import { relays } from "$lib/config";
+import { getGraphData } from "$lib/app";
+import { FLOW_LEVELS, notices, relays } from "$lib/config";
 
 const NEW_SITE_URL = "https://nostr-flowmeter.shino3.net/";
 // 旧 Vercel URL で閲覧しているときだけ移転案内を表示する
 const showMigrationNotice =
   browser && location.hostname.endsWith(".vercel.app");
+
+const MISSING_THRESHOLD_SEC = 30 * 60;
+
+type CurrentInfo = {
+  count: number | null;
+  updated: Date | null;
+  operation: "計測中" | "欠測" | "－";
+};
+
+let current: Record<string, CurrentInfo> = {};
+let fetchState: "loading" | "ready" | "error" = "loading";
+
+// 全観測所の現在値は単一イベントに含まれるため、取得は1回で済む
+async function fetchCurrent() {
+  try {
+    const result = await getGraphData("nostr_river_flowmeter");
+    if (!result) {
+      fetchState = "error";
+      return;
+    }
+    const axis: number[] = result.axis;
+    const latestTime = axis.length > 0 ? axis[axis.length - 1] : null;
+    const nowSec = Math.floor(Date.now() / 1000);
+    const map: Record<string, CurrentInfo> = {};
+    for (const relay of relays) {
+      const series: number[] | undefined = result.data[relay.key];
+      if (!series || series.length === 0 || latestTime === null) {
+        map[relay.key] = { count: null, updated: null, operation: "－" };
+        continue;
+      }
+      map[relay.key] = {
+        count: series[series.length - 1],
+        updated: fromUnixTime(latestTime),
+        operation:
+          nowSec - latestTime > MISSING_THRESHOLD_SEC ? "欠測" : "計測中",
+      };
+    }
+    current = map;
+    fetchState = "ready";
+  } catch (e) {
+    console.error("Failed to fetch current data:", e);
+    fetchState = "error";
+  }
+}
+
+if (browser) fetchCurrent();
+
+const countClass = (count: number | null): string => {
+  if (count === null) return "";
+  if (count >= FLOW_LEVELS.danger) return "cell-danger";
+  if (count >= FLOW_LEVELS.attention) return "cell-attention";
+  return "";
+};
 </script>
 
 <div class="bg-main text-center py-2">
@@ -27,102 +82,164 @@ const showMigrationNotice =
   </div>
 {/if}
 <div class="max-width mx-auto container pt-3">
-<div class="row">
-  <div class="col-12">
-    このサイトは Nostr 日本リレーの流速をグラフ表示化しています。<br />
-    流速ちゃんがリレー上に投稿したKind 30078 をデータベースとしたシステムで、nostr-key-value
-    プロジェクトのサンプルとしても提供されています。<br />
+  <!-- お知らせ -->
+  <div class="section-title">お知らせ</div>
+  <table class="notice-table">
+    <tbody>
+      {#each notices as notice}
+        <tr>
+          <td class="notice-date">{notice.date}</td>
+          <td class="text-start">
+            {#if notice.url}
+              <a href={notice.url}>{notice.text}</a>
+            {:else}
+              {notice.text}
+            {/if}
+          </td>
+        </tr>
+      {/each}
+    </tbody>
+  </table>
 
-    <br />
-    サイト管理者:
-    <a
-      href="https://nostx.shino3.net/npub1l60d6h2uvdwa9yq0r7r2suhgrnsadcst6nsx2j03xwhxhu2cjyascejxe5"
-      target="_blank" rel="noopener noreferrer"
-      class="text-success">shino3（しのさん）</a
-    ><br />
-    ページソース・質問・お問い合わせ:
-    <a
-      href="https://github.com/ShinoharaTa/nostr-flowmeter-site"
-      target="_blank" rel="noopener noreferrer">GitHub</a
-    >
+  <!-- 観測所一覧（現在値） -->
+  <div class="d-flex justify-content-between align-items-end mt-4">
+    <div class="section-title">観測所一覧</div>
+    <div class="table-note">(流速の単位: 投稿/10分)</div>
   </div>
-  <div class="col-md-9">
-    <table class="mt-3">
-      <thead>
-        <tr class="bg-sub">
-          <th>河川名</th>
-          <th>URI</th>
+  <table class="obs-table">
+    <thead>
+      <tr class="bg-sub">
+        <th>河川名</th>
+        <th class="d-none d-md-table-cell">所在地（リレー）</th>
+        <th>現在の流速</th>
+        <th>稼働状況</th>
+        <th>更新時刻</th>
+      </tr>
+    </thead>
+    <tbody>
+      {#each relays as relay}
+        {@const info = current[relay.key]}
+        <tr>
+          <td class="py-md-2">
+            <a href="/{relay.key}" class="text-primary">{relay.river_name}</a>
+          </td>
+          <td class="uri-cell d-none d-md-table-cell">{relay.relay_url}</td>
+          {#if fetchState === "loading"}
+            <td class="text-secondary">取得中</td>
+            <td class="text-secondary">取得中</td>
+            <td class="text-secondary">-</td>
+          {:else if info && info.count !== null}
+            <td class={countClass(info.count)}>{info.count}</td>
+            <td
+              class={info.operation === "計測中"
+                ? "text-success"
+                : "text-danger"}>{info.operation}</td
+            >
+            <td>{info.updated ? format(info.updated, "HH:mm") : "-"}</td>
+          {:else}
+            <td>-</td>
+            <td>－</td>
+            <td>-</td>
+          {/if}
         </tr>
-      </thead>
-      <tbody>
-        {#each relays as relay}
-          <tr>
-            <td class="py-md-3">
-              <a href="/{relay.key}" class="text-primary">{relay.river_name}</a>
-            </td>
-            <td class="uri-cell">
-              {relay.relay_url}
-            </td>
-          </tr>
-        {/each}
-      </tbody>
-    </table>
+      {/each}
+    </tbody>
+  </table>
+  {#if fetchState === "error"}
+    <div class="data-note mt-1">
+      現在値を取得できませんでした。時間をおいて再読み込みしてください。
+    </div>
+  {/if}
+  <div class="data-note mt-1">
+    このデータは速報値であり、後日修正されることがあります。各観測所名から詳細のグラフ・観測値を確認できます。
   </div>
-  <div class="col-md-3">
-    <table class="mt-3">
-      <thead>
-        <tr class="bg-sub">
-          <th>観測システム</th>
-        </tr>
-      </thead>
-      <tbody>
-      <tr>
-        <td
-          ><img
-            src="/image/ryusoku-chan.jpg"
-            alt="流速ちゃんのイラスト"
-            class="img-fluid"
-          /></td
-        >
-      </tr>
-      <tr>
-        <td
-          ><a
-            href="https://nostx.shino3.net/npub150qnaaxfan8auqdajvn292cgk2khm3tl8dmakamj878z44a6yntqk7uktv"
-            target="_blank" rel="noopener noreferrer"
-            class="text-success">流速ちゃん</a
-          ></td
-        >
-      </tr>
-      <tr>
-        <td
-          >日本リレーの流速を毎分計測します。<br />計測したデータはNIP-78 (Kind:
-          30078) に投稿され、記録されていきます。<br /></td
-        >
-      </tr>
-      <tr>
-        <td
-          >Illust by <a
-            href="https://nostx.shino3.net/npub1tuqsl6l8xzly95vv80um7wsnt7gxy8w9wgt4khp4wyv4xwhfw44slm93e9"
-            target="_blank" rel="noopener noreferrer">© りら</a
-          ></td
-        >
-      </tr>
-      </tbody>
-    </table>
-  </div>
-  <div class="col-12 mt-4">
-    <div class="h5">野洲田川水系 河川構成図</div>
-    <div><img src="/image/river_image.png" alt="野洲田川水系 河川構成図" class="img-fluid" /></div>
-    <div class="text-center">
+
+  <!-- 水系図 -->
+  <div class="section-title mt-4">野洲田川水系 水系図</div>
+  <div class="river-map mx-auto mt-2">
+    <img
+      src="/image/river_image.png"
+      alt="野洲田川水系 河川構成図"
+      class="img-fluid"
+    />
+    <div class="text-center credit">
       Illust by <a
         href="https://nostx.shino3.net/npub1e4qg56wvd3ehegd8dm7rlgj8cm998myq0ah8e9t5zeqkg7t7s93q750p76"
-        target="_blank" rel="noopener noreferrer">© あわゆき</a
+        target="_blank"
+        rel="noopener noreferrer">© あわゆき</a
       >
     </div>
   </div>
+
+  <!-- 本システムについて -->
+  <div class="section-title mt-4">本システムについて</div>
+  <div class="row">
+    <div class="col-md-8 pt-2">
+      このサイトは Nostr 日本リレーの流速をグラフ表示化しています。<br />
+      流速ちゃんがリレー上に投稿したKind 30078 をデータベースとしたシステムで、nostr-key-value
+      プロジェクトのサンプルとしても提供されています。<br />
+      <br />
+      サイト管理者:
+      <a
+        href="https://nostx.shino3.net/npub1l60d6h2uvdwa9yq0r7r2suhgrnsadcst6nsx2j03xwhxhu2cjyascejxe5"
+        target="_blank"
+        rel="noopener noreferrer"
+        class="text-success">shino3（しのさん）</a
+      ><br />
+      ページソース・質問・お問い合わせ:
+      <a
+        href="https://github.com/ShinoharaTa/nostr-flowmeter-site"
+        target="_blank"
+        rel="noopener noreferrer">GitHub</a
+      >
+    </div>
+    <div class="col-md-4">
+      <table class="mt-2">
+        <thead>
+          <tr class="bg-sub">
+            <th>観測システム</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td
+              ><img
+                src="/image/ryusoku-chan.jpg"
+                alt="流速ちゃんのイラスト"
+                class="img-fluid system-image"
+              /></td
+            >
+          </tr>
+          <tr>
+            <td
+              ><a
+                href="https://nostx.shino3.net/npub150qnaaxfan8auqdajvn292cgk2khm3tl8dmakamj878z44a6yntqk7uktv"
+                target="_blank"
+                rel="noopener noreferrer"
+                class="text-success">流速ちゃん</a
+              ></td
+            >
+          </tr>
+          <tr>
+            <td
+              >日本リレーの流速を毎分計測します。<br />計測したデータはNIP-78
+              (Kind: 30078) に投稿され、記録されていきます。<br /></td
+            >
+          </tr>
+          <tr>
+            <td
+              >Illust by <a
+                href="https://nostx.shino3.net/npub1tuqsl6l8xzly95vv80um7wsnt7gxy8w9wgt4khp4wyv4xwhfw44slm93e9"
+                target="_blank"
+                rel="noopener noreferrer">© りら</a
+              ></td
+            >
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
   <div class="p-4"></div>
-</div>
 </div>
 
 <style>
@@ -130,9 +247,17 @@ const showMigrationNotice =
     border: 2px solid #dc3545;
     background-color: #fff;
   }
+  .section-title {
+    font-size: 15px;
+    font-weight: bold;
+    border-left: 5px solid #0b346e;
+    border-bottom: 1px solid #0b346e;
+    padding: 2px 8px;
+  }
   table {
     width: 100%;
     border: 1px solid #000;
+    margin-top: 0.5rem;
   }
   td,
   th {
@@ -141,13 +266,55 @@ const showMigrationNotice =
     text-align: center;
     height: 1.5rem;
   }
+  .notice-table td {
+    text-align: left;
+  }
+  .notice-date {
+    width: 7em;
+    white-space: nowrap;
+    text-align: center !important;
+  }
+  .table-note {
+    font-size: 11px;
+    color: #666;
+  }
+  .data-note {
+    font-size: 11px;
+    color: #666;
+  }
+  .cell-attention {
+    background-color: #fff3cd;
+  }
+  .cell-danger {
+    background-color: #f8d7da;
+  }
   .uri-cell {
     word-break: break-all;
+  }
+  .river-map {
+    max-width: 640px;
+  }
+  .credit {
+    font-size: 11px;
+  }
+  .system-image {
+    max-width: 200px;
   }
   /* モバイルでは大見出しを一段階（fs-2 相当に）縮小する */
   @media (max-width: 575.98px) {
     .fs-1 {
       font-size: calc(1.325rem + 0.9vw) !important;
+    }
+  }
+  /* モバイルの観測所一覧: 見出しの縦折れを防ぐ */
+  @media (max-width: 767.98px) {
+    .obs-table th {
+      white-space: nowrap;
+      font-size: 12px;
+      padding: 5px 4px;
+    }
+    .obs-table td {
+      padding: 5px 4px;
     }
   }
 </style>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -9,8 +9,8 @@ const showMigrationNotice =
 </script>
 
 <div class="bg-main text-center py-2">
-  <div class="fs-1">野洲田川水系</div>
-  <div class="fs-3 mt-2">定点観測所</div>
+  <div class="fs-1">野洲田川水系 定点観測所</div>
+  <div class="fs-5">―リアルタイム流速情報―</div>
 </div>
 {#if showMigrationNotice}
   <div class="max-width mx-auto px-3">

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -26,7 +26,8 @@ const showMigrationNotice =
     </div>
   </div>
 {/if}
-<div class="row max-width mx-auto pt-3">
+<div class="max-width mx-auto container pt-3">
+<div class="row">
   <div class="col-12">
     このサイトは Nostr 日本リレーの流速をグラフ表示化しています。<br />
     流速ちゃんがリレー上に投稿したKind 30078 をデータベースとしたシステムで、nostr-key-value
@@ -59,7 +60,7 @@ const showMigrationNotice =
             <td class="py-md-3">
               <a href="/{relay.key}" class="text-primary">{relay.river_name}</a>
             </td>
-            <td>
+            <td class="uri-cell">
               {relay.relay_url}
             </td>
           </tr>
@@ -122,6 +123,7 @@ const showMigrationNotice =
   </div>
   <div class="p-4"></div>
 </div>
+</div>
 
 <style>
   .migration-notice {
@@ -138,5 +140,14 @@ const showMigrationNotice =
     border: 1px solid #000;
     text-align: center;
     height: 1.5rem;
+  }
+  .uri-cell {
+    word-break: break-all;
+  }
+  /* モバイルでは大見出しを一段階（fs-2 相当に）縮小する */
+  @media (max-width: 575.98px) {
+    .fs-1 {
+      font-size: calc(1.325rem + 0.9vw) !important;
+    }
   }
 </style>

--- a/src/routes/[relay]/+page.svelte
+++ b/src/routes/[relay]/+page.svelte
@@ -149,6 +149,13 @@ const selectDate = () => {
   >
 </div>
 
+<div class="max-width mx-auto container py-1">
+  <nav class="breadcrumb-list" aria-label="パンくずリスト">
+    <a href="/">トップ</a>
+    &gt; 野洲田川水系 &gt; {info.river_name}観測所
+  </nav>
+</div>
+
 <div class="bg-light-sub">
   <div
     class="max-width mx-auto d-md-flex justify-content-between align-items-bottom pb-3 container flex-row-reverse"
@@ -265,5 +272,12 @@ const selectDate = () => {
   .data-note {
     font-size: 11px;
     color: #666;
+  }
+  .breadcrumb-list {
+    font-size: 11px;
+  }
+  .breadcrumb-list a {
+    text-decoration: underline;
+    color: #0b346e;
   }
 </style>

--- a/src/routes/[relay]/+page.svelte
+++ b/src/routes/[relay]/+page.svelte
@@ -156,34 +156,18 @@ const selectDate = () => {
   </nav>
 </div>
 
-<div class="bg-light-sub">
-  <div
-    class="max-width mx-auto d-md-flex justify-content-between align-items-bottom pb-3 container flex-row-reverse"
-  >
-    <div class="bg-main py-2 px-3 head-sub-title">
-      Nostr 日本語リレーリアルタイム流速検出システム
-    </div>
-    <div class="pt-2">{info.relay_url}</div>
+<div class="max-width mx-auto container">
+  <div class="station-title">
+    {info.river_name}観測所
+    <span class="station-uri">（{info.relay_url}）</span>
   </div>
+  <div class="station-sub">Nostr 日本語リレー リアルタイム流速検出システム</div>
 </div>
-{#if info}
-  <div class="bg-light-sub">
-    <div
-      class="max-width mx-auto d-md-flex justify-content-between align-items-center container flex-row-reverse pt-2"
-    >
-      <div class="">
-        日付を選択：
-        <input
-          type="date"
-          class=""
-          bind:value={selectedDate}
-          on:change={selectDate}
-        />
-        {#if data.date === null && lastUpdated}
-          <div class="text-end">最終更新: {format(lastUpdated, "HH:mm")}</div>
-        {/if}
-      </div>
-      <div class="select-sector pt-2 pb-1 px-3 bg-white mt-2">
+
+<div class="bg-light-sub py-2 mt-2">
+  <div class="max-width mx-auto container">
+    <div class="control-bar">
+      <span class="control-group">
         <label for="mode-current" class="me-2">
           <input
             type="radio"
@@ -206,10 +190,19 @@ const selectDate = () => {
           />
           日付指定
         </label>
-      </div>
+      </span>
+      <span class="control-group">
+        日付を選択：
+        <input type="date" bind:value={selectedDate} on:change={selectDate} />
+      </span>
+      {#if data.date === null && lastUpdated}
+        <span class="control-group ms-md-auto">
+          最終更新: {format(lastUpdated, "HH:mm")}
+        </span>
+      {/if}
     </div>
   </div>
-{/if}
+</div>
 <div class="p-2"></div>
 
 {#if status === "ready" && axis && counts}
@@ -219,7 +212,7 @@ const selectDate = () => {
   <div class="p-2"></div>
   <div class="max-width mx-auto container">
     <div class="row">
-      <div class="col-12 col-md-3 order-2">
+      <div class="col-12 col-md-3 order-2 position-relative">
         <DataTable {axis} data={counts} />
       </div>
       <div class="col-12 col-md-9 order-1">
@@ -266,7 +259,32 @@ const selectDate = () => {
   a {
     text-decoration: none;
   }
-  .select-sector input {
+  .station-title {
+    font-size: 18px;
+    font-weight: bold;
+    border-left: 5px solid #0b346e;
+    border-bottom: 1px solid #0b346e;
+    padding: 2px 8px;
+    margin-top: 0.25rem;
+  }
+  .station-uri {
+    font-size: 12px;
+    font-weight: normal;
+    word-break: break-all;
+  }
+  .station-sub {
+    font-size: 11px;
+    color: #666;
+    padding-left: 13px;
+    margin-top: 2px;
+  }
+  .control-bar {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 0.25rem 1.5rem;
+  }
+  .control-bar input[type="radio"] {
     vertical-align: middle;
   }
   .data-note {

--- a/src/routes/[relay]/+page.svelte
+++ b/src/routes/[relay]/+page.svelte
@@ -248,11 +248,22 @@ const selectDate = () => {
   </div>
 {/if}
 
+<div class="max-width mx-auto container mt-3 mb-4">
+  <div class="data-note">
+    このデータは速報値であり、後日修正されることがあります。<br />
+    観測は毎分、表示は10分毎の集計値です。ページは5分毎に自動更新されます。
+  </div>
+</div>
+
 <style>
   a {
     text-decoration: none;
   }
   .select-sector input {
     vertical-align: middle;
+  }
+  .data-note {
+    font-size: 11px;
+    color: #666;
   }
 </style>

--- a/src/routes/[relay]/+page.svelte
+++ b/src/routes/[relay]/+page.svelte
@@ -252,13 +252,7 @@ const selectDate = () => {
   a {
     text-decoration: none;
   }
-  .select-sector {
-    border-radius: 10px 10px 0 0;
-  }
   .select-sector input {
     vertical-align: middle;
-  }
-  .head-sub-title {
-    border-radius: 0 0 10px 10px;
   }
 </style>

--- a/src/routes/[relay]/+page.svelte
+++ b/src/routes/[relay]/+page.svelte
@@ -210,33 +210,41 @@ const selectDate = () => {
     <BaseInfo {info} {operation} />
   </div>
   <div class="p-2"></div>
-  <div class="row max-width mx-auto">
-    <div class="col-12 col-md-3 order-2">
-      <DataTable {axis} data={counts} />
-    </div>
-    <div class="col-12 col-md-9 order-1">
-      <Charts {axis} data={counts} />
+  <div class="max-width mx-auto container">
+    <div class="row">
+      <div class="col-12 col-md-3 order-2">
+        <DataTable {axis} data={counts} />
+      </div>
+      <div class="col-12 col-md-9 order-1">
+        <Charts {axis} data={counts} />
+      </div>
     </div>
   </div>
 {:else if status === "nodata"}
-  <div class="row max-width mx-auto text-center mt-5">
-    <div class="fs-1"></div>
-    <div class="fs-3">No Data</div>
-    <div class="mt-4">指定日の観測データがありません</div>
+  <div class="max-width mx-auto container text-center mt-5">
+    <div class="row">
+      <div class="fs-1"></div>
+      <div class="fs-3">No Data</div>
+      <div class="mt-4">指定日の観測データがありません</div>
+    </div>
   </div>
 {:else if status === "error"}
-  <div class="row max-width mx-auto text-center mt-5">
-    <div class="fs-1"></div>
-    <div class="fs-3">Error</div>
-    <div class="mt-4">
-      データを取得できませんでした。時間をおいて再読み込みしてください
+  <div class="max-width mx-auto container text-center mt-5">
+    <div class="row">
+      <div class="fs-1"></div>
+      <div class="fs-3">Error</div>
+      <div class="mt-4">
+        データを取得できませんでした。時間をおいて再読み込みしてください
+      </div>
     </div>
   </div>
 {:else}
-  <div class="row max-width mx-auto text-center mt-5">
-    <div class="fs-1"></div>
-    <div class="fs-3">Now loading...</div>
-    <div class="mt-4">読み込み中</div>
+  <div class="max-width mx-auto container text-center mt-5">
+    <div class="row">
+      <div class="fs-1"></div>
+      <div class="fs-3">Now loading...</div>
+      <div class="mt-4">読み込み中</div>
+    </div>
   </div>
 {/if}
 


### PR DESCRIPTION
develop に蓄積した官公庁様式化・レスポンシブ整理の一式を本番（main）へリリースします。

## 含まれる変更（PR 単位）
- #40 グラフ整理と流速水準線の追加（横長比率化・注意/危険水準線・凡例・ツールチップ、#31 #34）
- #41 諸元表・データ表の官公庁様式化（モバイル2列縦様式・諸元拡充・水準超過セル強調、#32 #38）
- #42 官公庁風フッターと文字サイズ変更・印刷用表示（#36 #39）
- #43 レスポンシブ整理と様式化（モバイル横スクロール解消・角丸廃止・速報値注記・パンくず、#33 #35 #37 #38）
- #45 トップページの官公庁ポータル様式化（お知らせ欄・現在値付き観測所一覧・水系図・本システムについて、#44）
- #48 観測所ページの整列改善（操作バー統合・グラフと表の高さ揃え・諸元表折返し整理、#46 ※#47 の取りこぼし復旧）

## 対応 Issue
#31〜#39、#44、#46（すべてクローズ済み）

## 確認済み
- 各 PR で build / check / lint 全通過、デプロイチェック（Vercel / Cloudflare Pages）全通過
- モバイル（375px）/ PC（1280px）のスクリーンショットで UI 崩れがないことを確認（トップ・やぶみ川・きりの川）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CstqXvSDoZrhAMXGmfzdeD